### PR TITLE
Handle wildcard labels in :extra-deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,15 @@ Sometimes the dependency graph isn't complete, for example when using JVM librar
 ```clojure
 :bazel {:extra-deps {"@deps//:com_cognitect_aws_api" {:deps ["@deps//:com_cognitect_aws_endpoints"]}
                       "//src/foo/foo_s3" {:deps ["@deps//:com_cognitect_aws_s3"]}
-                      "@deps//:caesium_caesium" {:deps ["@griffin//native:libsodium"]}
+                      "@deps//:caesium_caesium" {:deps ["@griffin//native:libsodium"]
+                      "//test/..." {:deps ["@deps//::some_dep_for_all_tests"]}
 ```
 
 put `:bazel {:extra-deps {}}` at the top level of your deps.edn file. `:extra-deps` will be merged in when running `gen_srcs`
 
 Deps are a map of bazel labels to a map of extra fields to merge into `clojure_namespace` and imported deps.
+
+[Wildcard](https://docs.bazel.build/versions/master/guide.html#specifying-targets-to-build) rules are supported _only_ on the left hand side of extra-deps declarations. This is to ensure that overly broad dependencies aren't specified
 
 ## Resources
 

--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -364,9 +364,9 @@
   (let [path (path-relative-to workspace-root path)]
     (str "//" (dirname path) ":" (str (basename path)))))
 
-(s/fdef src->wildcards-for-label :args (s/cat :a (s/keys :req-un [::workspace-root]) :p path?) :ret (s/coll-of string?))
-(defn src->wildcards-for-label
-  "Return a collection of 'wildcard' labels that could match the given path"
+(s/fdef src->wildcard-patterns-for-path :args (s/cat :a (s/keys :req-un [::workspace-root]) :p path?) :ret (s/coll-of string?))
+(defn src->wildcard-patterns-for-path
+  "Return a collection of 'wildcard' target patterns that could match the given path"
   [{:keys [workspace-root]} path]
   (let [path (path-relative-to workspace-root path)
         subpaths (map #(.subpath path 0 (inc %)) (range (.getNameCount path)))]
@@ -504,9 +504,9 @@
   "get extra dependencies, handling wildcard labels as per
   https://docs.bazel.build/versions/master/guide.html#specifying-targets-to-build"
   [{:keys [deps-bazel] :as args} path]
-  (let [candidate-labels (conj (src->wildcards-for-label args path)
+  (let [target-patterns (conj (src->wildcard-patterns-for-path args path)
                                (src->label args path))]
-    (->> candidate-labels
+    (->> target-patterns
          (mapcat (fn [label] (get-in deps-bazel [:extra-deps label])))
          seq)))
 


### PR DESCRIPTION
Allows extra-deps for multiple targets, based on the rules for
specifying wildcards in bazel.

Note: It is not clear whether supporting :* and :all-targets for
matching extra-deps is the right thing to do, the distinction between
:all and :all-targets is the distinction between rules and (rules + files)