### PR TITLE
Add shim runtime deps to worker inputs

### DIFF
--- a/rules/jar.bzl
+++ b/rules/jar.bzl
@@ -149,7 +149,7 @@ def clojure_jar_impl(ctx):
         output = args_file,
         content = json.encode(compile_args))
 
-    inputs = ctx.files.srcs + ctx.files.resources + dep_info.transitive_deps.to_list() + dep_info.transitive_runtime_deps.to_list() + native_libs + [args_file] + ctx.files._worker_runtime
+    inputs = ctx.files.srcs + ctx.files.resources + dep_info.transitive_deps.to_list() + dep_info.transitive_runtime_deps.to_list() + native_libs + [args_file] + ctx.files._worker_runtime + shim_info.transitive_runtime_deps.to_list()
 
     ctx.actions.run(
         executable=ctx.executable.worker,


### PR DESCRIPTION
This fixes the following exception observed in the worker:
```
Exception in thread "main" Syntax error macroexpanding clojure.core/ns
at (rules_clojure/jar.clj:1:1).
at clojure.lang.Compiler.checkSpecs(Compiler.java:6976)
at clojure.lang.Compiler.macroexpand1(Compiler.java:6992)
at clojure.lang.Compiler.macroexpand(Compiler.java:7079)
at clojure.lang.Compiler.eval(Compiler.java:7165)
at clojure.lang.Compiler.load(Compiler.java:7640)
at clojure.lang.RT.loadResourceScript(RT.java:381)
at clojure.lang.RT.loadResourceScript(RT.java:372)
at clojure.lang.RT.load(RT.java:459)
at clojure.lang.RT.load(RT.java:424)
at clojure.core$load$fn__6856.invoke(core.clj:6115)
at clojure.core$load.invokeStatic(core.clj:6114)
at clojure.core$load.doInvoke(core.clj:6098)
at clojure.lang.RestFn.invoke(RestFn.java:408)
at clojure.core$load_one.invokeStatic(core.clj:5897)
at clojure.core$load_one.invoke(core.clj:5892)
at clojure.core$load_lib$fn__6796.invoke(core.clj:5937)
at clojure.core$load_lib.invokeStatic(core.clj:5936)
at clojure.core$load_lib.doInvoke(core.clj:5917)
at clojure.lang.RestFn.applyTo(RestFn.java:142)
at clojure.core$apply.invokeStatic(core.clj:669)
at clojure.core$load_libs.invokeStatic(core.clj:5974)
at clojure.core$load_libs.doInvoke(core.clj:5958)
at clojure.lang.RestFn.applyTo(RestFn.java:137)
at clojure.core$apply.invokeStatic(core.clj:669)
at clojure.core$require.invokeStatic(core.clj:5996)
at clojure.core$require.doInvoke(core.clj:5996)
at clojure.lang.RestFn.invoke(RestFn.java:408)
at clojure.lang.Var.invoke(Var.java:384)
at org.projectodd.shimdandy.impl.ClojureRuntimeShimImpl.require(ClojureRuntimeShimImpl.java:73)
at rules_clojure.ClojureWorker.processRequest(ClojureWorker.java:205)
at rules_clojure.ClojureWorker.persistentWorkerMain(ClojureWorker.java:156)
at rules_clojure.ClojureWorker.main(ClojureWorker.java:117)
Caused by: java.io.FileNotFoundException: Could not locate
clojure/spec/alpha__init.class, clojure/spec/alpha.clj or
clojure/spec/alpha.cljc on classpath.
at clojure.lang.RT.load(RT.java:462)
at clojure.lang.RT.load(RT.java:424)
at clojure.lang.Compiler.ensureMacroCheck(Compiler.java:6961)
at clojure.lang.Compiler.checkSpecs(Compiler.java:6974)
... 31 more
```