### PR TITLE
fix: put distinct back

### DIFF
--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -708,7 +708,7 @@
                         (emit-bazel (list 'clojure_library (kwargs {:name "__clj_lib"
                                                                     :deps (vec
                                                                            (concat
-                                                                            (distinct (map (fn [p] (str ":" (fs/basename p))) paths))
+                                                                            (dedupe (map (fn [p] (str ":" (fs/basename p))) paths))
                                                                             (map (fn [p]
                                                                                    (str "//" (fs/path-relative-to deps-edn-dir p) ":__clj_lib")) clj-subdirs)))})))
                         "\n"

--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -708,7 +708,7 @@
                         (emit-bazel (list 'clojure_library (kwargs {:name "__clj_lib"
                                                                     :deps (vec
                                                                            (concat
-                                                                            (map (fn [p] (str ":" (fs/basename p))) paths)
+                                                                            (distinct (map (fn [p] (str ":" (fs/basename p))) paths))
                                                                             (map (fn [p]
                                                                                    (str "//" (fs/path-relative-to deps-edn-dir p) ":__clj_lib")) clj-subdirs)))})))
                         "\n"


### PR DESCRIPTION
In my last PR: https://github.com/griffinbank/rules_clojure/pull/7/files#diff-7425d04e2b9d01ea954bb5deef8941e306d1ddae09b2995068d4476be1e93b7aL714

I removed the use of `distinct`: this was incorrect!

From the list of `paths`, calling `fs/basename` can return the same base name (in fact there is a `group-by` just above using this fact).

This would result in incorrect behavior when there is ex. a `code.clj` and `code.cljs` file in the same directory
