### PR TITLE
One clojure version to rule them all

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -21,11 +21,7 @@ clojure_library = rule(
         ## at runtime
         "jar_runtime": attr.label_list(default=[Label("@rules_clojure_maven//:org_projectodd_shimdandy_shimdandy_impl"),
                                                 Label("@rules_clojure//src/rules_clojure:jar-lib")], cfg="host"),
-        "worker_runtime": attr.label_list(default=[Label("@rules_clojure_maven//:org_projectodd_shimdandy_shimdandy_impl"),
-                                                   #TODO toolchain here
-                                                   Label("@rules_clojure_maven//:org_clojure_clojure"),
-                                                   Label("@rules_clojure_maven//:org_clojure_spec_alpha"),
-                                                   Label("@rules_clojure_maven//:org_clojure_core_specs_alpha")], cfg="host")
+        "worker_runtime": attr.label_list(default=[Label("@rules_clojure_maven//:org_projectodd_shimdandy_shimdandy_impl")], cfg="host")
     },
     provides = [JavaInfo],
     implementation = _clojure_jar_impl,

--- a/rules/jar.bzl
+++ b/rules/jar.bzl
@@ -131,7 +131,7 @@ def clojure_jar_impl(ctx):
     else:
         src_dir = None
 
-    compile_classpath = compile_info.transitive_runtime_deps.to_list() + jar_info.transitive_runtime_deps.to_list() + ctx.files.compiledeps + [classes_dir]
+    compile_classpath = compile_info.transitive_runtime_deps.to_list() + ctx.files.compiledeps + [classes_dir]
     compile_classpath = [f.path for f in compile_classpath]
     compile_classpath = compile_classpath + [p for p in [src_dir] if p]
 

--- a/src/rules_clojure/BUILD.bazel
+++ b/src/rules_clojure/BUILD.bazel
@@ -22,7 +22,10 @@ clojure_library(
     resource_strip_prefix="src",
     aot=["rules-clojure.fs"],
     jar_runtime=["@rules_clojure_maven//:org_projectodd_shimdandy_shimdandy_impl",
-                 "@rules_clojure//src/rules_clojure:jar-lib-bootstrap"])
+                 "@rules_clojure//src/rules_clojure:jar-lib-bootstrap"],
+    deps=["@rules_clojure_maven//:org_clojure_clojure",
+          "@rules_clojure_maven//:org_clojure_spec_alpha",
+          "@rules_clojure_maven//:org_clojure_core_specs_alpha"])
 
 clojure_library(
     name="jar-lib",
@@ -87,7 +90,8 @@ java_binary(name="gen_build",
 clojure_library(name= "testrunner",
                 srcs=["testrunner.clj"],
                 resource_strip_prefix="src",
-                aot=["rules-clojure.testrunner"])
+                aot=["rules-clojure.testrunner"],
+                deps=["@rules_clojure_maven//:org_clojure_clojure"])
 
 ## files needed for the clj toolchain
 filegroup(name="toolchain_files",

--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -839,7 +839,8 @@
                                                                                                         into
                                                                                                         {:name (internal-dep-ns-aot-label lib ns)
                                                                                                          :aot [(str ns)]
-                                                                                                         :deps [(str deps-repo-tag "//:" label)]
+                                                                                                         :deps [(str deps-repo-tag "//:" label)
+                                                                                                                (str deps-repo-tag "//:org_clojure_clojure")]
                                                                                                          ;; TODO the source jar doesn't need to be in runtime_deps
                                                                                                          :runtime_deps []}
                                                                                                         (ns-deps (select-keys args [:dep-ns->label :jar->lib :deps-repo-tag]) ns-decl :clj)


### PR DESCRIPTION
Prevent rules_clojure dependencies from leaking into the application, and clobbering e.g. the version of Clojure in use by the application.