### PR TITLE
Update ci.yml to match default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default branch is now main, not master. This lets CI build again.