### PR TITLE
bump max metaspace to 1g

### DIFF
--- a/java/rules_clojure/BUILD.bazel
+++ b/java/rules_clojure/BUILD.bazel
@@ -12,7 +12,7 @@ java_binary(
     name = "ClojureWorker",
     main_class = "rules_clojure.ClojureWorker",
     runtime_deps = [":ClojureWorker-lib"],
-    jvm_flags = ["-Xmx500m", "-XX:MaxMetaspaceSize=500m"]
+    jvm_flags = ["-Xmx500m", "-XX:MaxMetaspaceSize=1g"]
 )
 
 proto_library(


### PR DESCRIPTION
Not clear how much we actually need, and whether we should even put a ceiling on this. I suppose if we're using more than 1GB then something's probably not working as expected. 500MB is _a lot_ already - we should probably look into why that's getting exceeded.