### PR TITLE
Use rules-clojure.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Please see [example](examples/setup/custom) of custom toolchain.
 # Known Issues
 
 - builds are non-reproducible for two reasons:
-  - Builds set the file modification time to current time. This is because clojure.lang.RT looks at file modification times when deciding whether to load a .clj or .class file. Setting the file modification time to zero for .class files would mean that if a source .clj is on the classpath (e.g. in a source dependency), it would always take precedence over an AOT .class file
+  - Builds set the file modification time to current time. This is because clojure.lang.RT looks at file modification times when deciding whether to load a .clj or .class file. Setting the file modification time to the epoch for .class files would mean that if a source .clj is on the classpath with a non-zero modification time, it would always take precedence over an AOT .class file
   - there isn't a public API to reset the ID clojure uses for naming anonymous functions, which means anonymous AOT function names are non-deterministic
 - When using gen-deps, I haven't found a way to identify :provided dependencies. Those have to be added by hand for now
 - Do not use `user.clj`. If there is a user.clj at the root of your classpath, it will be loaded every time a new Clojure runtime is created. Additionally, dependencies in the user.clj are invisible to `gen-build`

--- a/src/rules_clojure/bootstrap_worker.clj
+++ b/src/rules_clojure/bootstrap_worker.clj
@@ -23,6 +23,7 @@
     clojure.tools.namespace.find
     rules-clojure.persistentClassLoader
     rules-clojure.util
+    rules-clojure.parse
     rules-clojure.persistent-classloader
     rules-clojure.jar
     rules-clojure.fs

--- a/src/rules_clojure/jar.clj
+++ b/src/rules_clojure/jar.clj
@@ -8,7 +8,7 @@
             [clojure.spec.alpha :as s]
             [clojure.tools.namespace.file :as file]
             [clojure.tools.namespace.find :as find]
-            [clojure.tools.namespace.parse :as parse]
+            [rules-clojure.parse :as parse]
             [clojure.tools.namespace.track :as track]
             [clojure.tools.namespace.dependency :as dep]
             [rules-clojure.fs :as fs])


### PR DESCRIPTION
Use `rules-clojure.parse` rather than `c.t.n.parse` in jar.clj. We were already using rules-clojure.parse (used to fix handling of `:as-alias` in 1.11), in gen-build, but weren't using it in rules-clojure.jar. 

This fixes a bug where bazel dependencies were incorrect in sandboxed build modes (i.e. non-worker and remote). The bug doesn't manifest when using the persistent worker, because workers are not sandboxed. 