### PR TITLE
Fix parallel bazel executions on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cpcache
 .ijwb/
 bazel-*
 

--- a/rules/tools_deps.bzl
+++ b/rules/tools_deps.bzl
@@ -89,6 +89,13 @@ java_binary(name="gen_srcs",
             deps_build_dir = repository_ctx.path(""),
             aliases = aliases_str(repository_ctx.attr.aliases)))
 
+def _symlink_config_files(repository_ctx):
+    repository_ctx.execute(["mkdir", "-p", repository_ctx.os.environ["HOME"] + "/.clojure/tools"])
+    repository_ctx.symlink(repository_ctx.os.environ["HOME"] + "/.clojure/deps.edn",
+                           repository_ctx.path(clj_install_prefix + "/example-deps.edn"))
+    repository_ctx.symlink(repository_ctx.os.environ["HOME"] + "/.clojure/tools/tools.edn",
+                           repository_ctx.path(clj_install_prefix + "/tools.edn"))
+
 def _symlink_repository(repository_ctx):
     repository_ctx.symlink(repository_ctx.os.environ["HOME"] + "/.m2/repository", repository_ctx.path("repository"))
 
@@ -118,6 +125,7 @@ def _tools_deps_impl(repository_ctx):
     _install_tools_deps(repository_ctx)
     _add_deps_edn(repository_ctx)
     _symlink_repository(repository_ctx)
+    _symlink_config_files(repository_ctx)
     _install_scripts(repository_ctx)
     _run_gen_build(repository_ctx)
     return None


### PR DESCRIPTION
Sometimes `rules_clojure` fails with an error in `tools_deps.bzl/_run_gen_build`, which claims that it couldn't copy to `/root/.clojure/deps.edn` (i.e. `~/.clojure/deps.edn` for `root`), because the file already exists.

This appears to be a step in the `/usr/local/bin/clojure` script. When run, it checks for the existence of `~/.clojure/deps.edn` (by default), and copies a file into there from the install dir if not.

My theory is that multiple `clojure` runs are occurring at the same time in the same container. When that happens, there can be a race condition where they both detect that the file is not present, and then both try to copy the example file in. One wins, the other gets an error.

To prevent this race condition due to the behaviour of `cp`, we now set up these files within the `rules_clojure` Bazel functions, before the first call of `clojure`.