### PR TITLE
Fix `persistent-worker` exit code

### DIFF
--- a/rules/jar.bzl
+++ b/rules/jar.bzl
@@ -162,9 +162,9 @@ def clojure_jar_impl(ctx):
         inputs = inputs,
         mnemonic = "ClojureCompile",
         progress_message = "Compiling %s" % ctx.label,
-        execution_requirements={"supports-workers":"1",
+        execution_requirements={"supports-workers": "1",
                                 "supports-multiplex-workers": "1",
-                                "requires-worker-protocol" : "json"})
+                                "requires-worker-protocol": "json"})
 
     return [
         default_info,

--- a/src/rules_clojure/worker.clj
+++ b/src/rules_clojure/worker.clj
@@ -5,7 +5,7 @@
             [clojure.spec.alpha :as s]
             [rules-clojure.jar :as jar]
             [rules-clojure.util :as util]
-            [rules-clojure.persistent-classloader :as pcl ])
+            [rules-clojure.persistent-classloader :as pcl])
   (:import java.nio.charset.StandardCharsets
            java.util.concurrent.TimeUnit))
 
@@ -75,7 +75,7 @@
                      1)))
           _ (.flush out-printer)
           resp (merge
-                {:exit_code exit
+                {:exitCode exit
                  :output (str baos)}
                 (when requestId
                   {:requestId requestId}))]


### PR DESCRIPTION
According to the docs at
https://bazel.build/remote/persistent#implementation, the protobuf definition for persistent workers uses snake case, but the JSON implementation uses camel case. It also specifies that the JSON version should ignore any fields it gets that it doesn't recognise.

Given `:exit_code` was specified in our response map, instead of `:exitCode`, I believe Bazel was never detecting the exit code from a persistent worker job, and was just defaulting to the assumption that the build succeeded. This is why the compilation failure in the code the data team is working on for the chart of accounts migration etc managed to get into the primary branch.