### PR TITLE
Also discard on deftypes

### DIFF
--- a/src/rules_clojure/persistent_classloader.clj
+++ b/src/rules_clojure/persistent_classloader.clj
@@ -132,7 +132,7 @@
                                (require 'rules-clojure.compile)
                                (some (fn [n#]
                                        (or (rules-clojure.compile/contains-protocols? (symbol n#))
-                                           )) [~@aot-nses])))
+                                           (rules-clojure.compile/contains-deftypes? (symbol n#)))) [~@aot-nses])))
                 contains-protocols? (util/shim-eval classloader script)]
             (if-not contains-protocols?
               (.set cache {:input-map input-jars


### PR DESCRIPTION
Also discard the classloader when the namespace being compiled contains deftypes. This line used to be in main before #28, but I thought it wasn't necessary. I was wrong. 