### PR TITLE
Discard the environment when the namespace is already loaded

### DIFF
--- a/src/rules_clojure/compile.clj
+++ b/src/rules_clojure/compile.clj
@@ -82,6 +82,10 @@
   (binding [*out* *err*]
     (apply println args)))
 
+(defn loaded? [ns]
+  (assert (symbol? ns))
+  (contains? (loaded-libs) ns))
+
 (defn unconditional-compile
   "the clojure compiler works by binding *compile-files* true and then
   calling `load`. `load` looks for both the source file and .class. If
@@ -96,6 +100,8 @@
   [ns]
   (let [[src-path src-resource] (src-resource ns)]
     (assert src-resource (print-str "couldn't find a .clj or .cljc file for" ns "on classpath"))
+    (when  (loaded? ns)
+      (println "WARNING" ns "already loaded"))
     (try
       (with-open [rdr (clojure.java.io/reader src-resource)]
         (binding [*out* *err*

--- a/src/rules_clojure/persistent_classloader.clj
+++ b/src/rules_clojure/persistent_classloader.clj
@@ -115,7 +115,14 @@
                               (into {}))
               cp-dirs (set (remove jar? classpath))
 
-              cacheable-classloader (if (and cl-cache (compatible-inputs? input-jars input-cache))
+              cacheable-classloader (if (and cl-cache
+                                             (compatible-inputs? input-jars input-cache)
+                                             (every? (fn [ns]
+                                                       (let [loaded? (util/shim-eval cl-cache (str
+                                                                                               `(do
+                                                                                                  (require 'rules-clojure.compile)
+                                                                                                  (rules-clojure.compile/loaded? (symbol ~ns)))))]
+                                                         (not loaded?))) aot-nses))
                                       (let [cp-new (set/difference (set (keys input-jars)) (set (keys input-cache)))]
                                         (doseq [p cp-new]
                                           (add-url cl-cache p))


### PR DESCRIPTION
Fixes #31 