### PR TITLE
Bump Clojure Tools

### DIFF
--- a/rules/tools_deps.bzl
+++ b/rules/tools_deps.bzl
@@ -1,14 +1,13 @@
 load("//:rules.bzl", "clojure_library", "clojure_binary")
 
 CLJ_VERSIONS_MAC = {
-    "1.10.1.763": ("https://download.clojure.org/install/clojure-tools-1.10.1.763.tar.gz", "2a3ec8a6c3639035c2bba10945ae9007ab0dc9136766b95d2161f354e62a4d10"),
-    "1.11.1.1113": ("https://download.clojure.org/install/clojure-tools-1.11.1.1113.tar.gz", "0c954a56a071f33b9e039f8ab905f8372a5a601a0d14a32e0ccf230ea7606a22")
+    "1.10.3.1087": ("https://download.clojure.org/install/clojure-tools-1.10.3.1087.tar.gz", "a6b3b3547adc6da6ca5cfe10e037f1fde88a78f948372bb598ef4d0859da3e94"),
+    "1.11.1.1347": ("https://download.clojure.org/install/clojure-tools-1.11.1.1347.tar.gz", "d5e6c03e4eb8b49b7f0a9b77a4a7cc4cde7460004a3df96a1b4e797f842ebfe3")
 }
 
 CLJ_VERSIONS_LINUX = {
-    "1.10.1.763": ("https://download.clojure.org/install/linux-install-1.10.1.763.sh", "91421551872d421915c4a598741aefcc6749d3f4aafca9c08f271958e5456e2c"),
-    "1.10.2.774": ("https://download.clojure.org/install/linux-install-1.10.2.774.sh", "6d39603e84ad2622e5ae601436f02a1ee4a57e4e35dc49098b01a7d142a13d4a"),
-    "1.11.1.1113": ("https://download.clojure.org/install/linux-install-1.11.1.1113.sh", "7677bb1179ebb15ebf954a87bd1078f1c547673d946dadafd23ece8cd61f5a9f")
+    "1.10.3.1087": ("https://download.clojure.org/install/linux-install-1.10.3.1087.sh", "fd3d465ac30095157ce754f1551b840008a6e3503ce5023d042d0490f7bafb98"),
+    "1.11.1.1347": ("https://download.clojure.org/install/linux-install-1.11.1.1347.sh", "d9158bf3a1d92fbf8551656e47a86f42e93d10f1db9defa2124bfee206ce8c8f")
 }
 
 clj_install_prefix = "tools.deps"
@@ -126,7 +125,7 @@ clojure_tools_deps = repository_rule(
     _tools_deps_impl,
     attrs = {"deps_edn": attr.label(allow_single_file = True),
              "aliases": attr.string_list(default = [], doc = "extra aliases in deps.edn to merge in while resolving deps"),
-             "clj_version": attr.string(default="1.11.1.1113"),
+             "clj_version": attr.string(default="1.11.1.1347"),
              "_rules_clj_deps": attr.label(default="@rules_clojure//:deps.edn"),
              "_rules_clj_src": attr.label(default="@rules_clojure//:src")})
 


### PR DESCRIPTION
Update Clojure Tools [1] to the latest releases of 1.10.3 and 1.11.1.

[1] https://clojure.org/releases/tools

We need to update because older releases of Clojure Tools have been removed from https://download.clojure.org/install.