### PR TITLE
Improve worker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,7 @@ This makes things much nicer and more standard for users of the rules.
 
 # Known Issues
 
-- builds are non-reproducible for two reasons:
-  - Builds set the file modification time to current time. This is because clojure.lang.RT looks at file modification times when deciding whether to load a .clj or .class file. Setting the file modification time to the epoch for .class files would mean that if a source .clj is on the classpath with a non-zero modification time, it would always take precedence over an AOT .class file
+- builds are non-reproducible for one reason:
   - there isn't a public API to reset the ID clojure uses for naming anonymous functions, which means anonymous AOT function names are non-deterministic
 - When using gen-deps, I haven't found a way to identify :provided dependencies. Those have to be added by hand for now
 - Do not use `user.clj`. If there is a user.clj at the root of your classpath, it will be loaded every time a new Clojure runtime is created, which can be many times during an AOT job. Additionally, dependencies in the user.clj are invisible to `gen-build`

--- a/rules.bzl
+++ b/rules.bzl
@@ -12,14 +12,14 @@ clojure_library = rule(
         "resource_strip_prefix": attr.string(default = ""),
         "compiledeps": attr.label_list(default = []),
         "javacopts": attr.string_list(default = [], allow_empty = True, doc = "Optional javac compiler options"),
-
-        "_clojureworker_binary": attr.label(doc="Label for the ClojureWorker binary",
-                                            default=Label("@rules_clojure//src/rules_clojure:worker"), executable = True, cfg="exec"),
-
-        "_libcompile": attr.label_list(doc="extra jars to go in the compile env", default = [Label("@rules_clojure//src/rules_clojure:libcompile")])
+        "jvm_flags": attr.string_list(default=[], doc = "Optional jvm_flags to pass to the worker binary"),
+        "_jdk": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_runtime"), providers = [java_common.JavaRuntimeInfo],),
+        "_libworker": attr.label_list(doc="extra jars to go in the worker env", default = [Label("@rules_clojure//src/rules_clojure:libworker")], providers=[[JavaInfo]]),
+        "_libcompile": attr.label_list(doc="extra jars to go in the compile env", default = [Label("@rules_clojure//src/rules_clojure:libcompile")], providers=[[JavaInfo]])
     },
     provides = [JavaInfo],
     implementation = _clojure_jar_impl)
+
 
 def clojure_binary(name, **kwargs):
     deps = kwargs.pop("deps", [])


### PR DESCRIPTION
Previously we relied on a bazel `java_binary` to start the worker. That precludes passing `:jvm_opts`, which among other things prevents compiling code that requires `--enable-preview`. This reworks worker startup, and enables passing `:jvm_opts` to `clojure_library`. 