### PR TITLE
Fix performance regression

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -13,11 +13,12 @@ clojure_library = rule(
         "compiledeps": attr.label_list(default = []),
         "javacopts": attr.string_list(default = [], allow_empty = True, doc = "Optional javac compiler options"),
         "jvm_flags": attr.string_list(default=[], doc = "Optional jvm_flags to pass to the worker binary"),
-        "_jdk": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_runtime"), providers = [java_common.JavaRuntimeInfo],),
+        "_clojureworker_binary": attr.label(doc="Label for the ClojureWorker binary", default=Label("@rules_clojure//src/rules_clojure:worker"), executable = True, cfg="exec"),
         "_libworker": attr.label_list(doc="extra jars to go in the worker env", default = [Label("@rules_clojure//src/rules_clojure:libworker")], providers=[[JavaInfo]]),
         "_libcompile": attr.label_list(doc="extra jars to go in the compile env", default = [Label("@rules_clojure//src/rules_clojure:libcompile")], providers=[[JavaInfo]])
     },
     provides = [JavaInfo],
+    toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
     implementation = _clojure_jar_impl)
 
 

--- a/src/rules_clojure/worker.clj
+++ b/src/rules_clojure/worker.clj
@@ -130,6 +130,8 @@
 (defn -main [& args]
   (set-uncaught-exception-handler!)
   (let [persistent? (some (fn [a] (= "--persistent_worker" a)) args)
+        _ (when-not persistent?
+            (util/print-err "warning, non-persistent compilation, this will likely be slow"))
         f (if persistent?
             (fn [_args] (process-persistent))
             process-ephemeral)]


### PR DESCRIPTION
The previous PR introduce a performance regression which broke persistent workers, resulting in slow compilations.

I was calling `ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path` directly because I thought `java_binary` didn't support jvm_flags as an argument. For reasons I don't understand, bazel refuses to allow that to be a persistent worker. 

Reading the actual shell script shows that it does support `--jvm_flag=`, so use the old style java_binary and pass `--jvm_flag` to it. 