### PR TITLE
Remove noisy warning

### DIFF
--- a/src/rules_clojure/worker.clj
+++ b/src/rules_clojure/worker.clj
@@ -130,8 +130,6 @@
 (defn -main [& args]
   (set-uncaught-exception-handler!)
   (let [persistent? (some (fn [a] (= "--persistent_worker" a)) args)
-        _ (when-not persistent?
-            (util/print-err "warning, non-persistent compilation, this will likely be slow"))
         f (if persistent?
             (fn [_args] (process-persistent))
             process-ephemeral)]


### PR DESCRIPTION
I added this warning after fixing #43. When running locally, the warning remains a good idea. However, under RBE remote persistent workers are not supported, which means fires uselessly on every target under RBE, and I'm not aware of a way to distinguish local from RBE operation. 