### PR TITLE
double Xmx, MaxMetaspaceSize

### DIFF
--- a/src/rules_clojure/BUILD
+++ b/src/rules_clojure/BUILD
@@ -61,8 +61,8 @@ java_import(name="libcompile",
 java_binary(name="worker",
             main_class="clojure.main",
             jvm_flags=["-Dclojure.main.report=stderr",
-                       "-Xmx1g",
-                       "-XX:MaxMetaspaceSize=2g"],
+                       "-Xmx2g",
+                       "-XX:MaxMetaspaceSize=4g"],
             runtime_deps=["libworker"])
 
 clojure_library(name="libfs",


### PR DESCRIPTION
When building a large application:
- the max allowed heap size is used
- max allowed metaspace size is exceeded and the build fails with an `OutOfMemoryError`.

Increasing MaxMetaspaceSize may just be a temporary fix. It's possible we're preventing garbage collection of loaded classes, but I haven't investigated this yet.