### PR TITLE
parallelise gen-dir calls

### DIFF
--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -15,11 +15,30 @@
   (:import (clojure.lang IPersistentList IPersistentMap IPersistentVector Keyword Var)
            (java.io File)
            (java.nio.file Path)
+           (java.util.concurrent ExecutorService Executors Future TimeUnit)
            (java.util.jar JarEntry JarFile))
   (:gen-class))
 
 (set! *warn-on-reflection* true)
 
+(defn thread-pool-pmap
+  "pmap but uses the provided executor. eagerly submits futures."
+  [^ExecutorService pool f coll]
+  (let [futures (mapv (fn [item]
+                       (.submit pool ^Callable (fn []
+                                                 (f item))))
+                     coll)]
+    (map (fn [^Future fut] (.get fut)) futures)))
+
+(defn shutdown-pool [^ExecutorService pool timeout-ms]
+  (.shutdown pool)
+  (try
+    (when-not (.awaitTermination pool timeout-ms TimeUnit/MILLISECONDS)
+      (.shutdownNow pool))
+    (catch InterruptedException _
+      (.shutdownNow pool))))
+
+(s/def ::pool #(instance? % ExecutorService))
 (s/def ::ns-path (s/map-of symbol? ::fs/absolute-path))
 (s/def ::read-deps map?)
 (s/def ::aliases (s/coll-of keyword?))
@@ -735,10 +754,10 @@
         fs/path->file
         (spit content :encoding "UTF-8"))))
 
-(s/fdef gen-source-paths- :args (s/cat :a (s/keys :req-un [::deps-edn-dir ::src-ns->label ::dep-ns->label ::jar->lib ::deps-repo-tag ::deps-bazel]) :paths (s/coll-of fs/path?)))
+(s/fdef gen-source-paths- :args (s/cat :a (s/keys :req-un [::deps-edn-dir ::src-ns->label ::dep-ns->label ::jar->lib ::deps-repo-tag ::deps-bazel ::pool]) :paths (s/coll-of fs/path?)))
 (defn gen-source-paths-
   "gen-dir for every directory on the classpath."
-  [args paths]
+  [{:keys [pool] :as args} paths]
   (assert (map? (:src-ns->label args)))
   (->> paths
        (mapcat (fn [path]
@@ -747,8 +766,8 @@
        (distinct)
        (sort-by (comp count str))
        (reverse)
-       (map (fn [dir]
-              (gen-dir args dir)))
+       (thread-pool-pmap pool (fn [dir]
+                                (gen-dir args dir)))
        (dorun)))
 
 (defn path->absolute
@@ -791,7 +810,7 @@
      (remove (fn [path]
                (contains? ignore path))))))
 
-(s/fdef gen-source-paths :args (s/cat :a (s/keys :req-un [::deps-edn-path ::deps-bazel ::repository-dir ::deps-repo-tag ::basis ::jar->lib ::deps-bazel]
+(s/fdef gen-source-paths :args (s/cat :a (s/keys :req-un [::deps-edn-path ::deps-bazel ::repository-dir ::deps-repo-tag ::basis ::jar->lib ::deps-bazel ::pool]
                                                  :opt-un [::aliases])))
 (defn gen-source-paths
   "Given the path to a deps.edn file, gen-dir every source file on the classpath
@@ -800,7 +819,7 @@
   repository-dir: output directory in the bazel sandbox where deps should be downloaded
   deps-repo-tag: Bazel workspace repo for deps, typically `@deps`
   "
-  [{:keys [deps-edn-path deps-bazel deps-repo-tag basis jar->lib aliases] :as args}]
+  [{:keys [deps-edn-path deps-bazel deps-repo-tag basis jar->lib aliases pool] :as args}]
   (let [args (merge args
                     {:src-ns->label (->src-ns->label args)
                      :dep-ns->label (->dep-ns->label args)
@@ -932,7 +951,7 @@
                      :lib->jar lib->jar
                      :lib->deps lib->deps})))
 
-(defn srcs [{:keys [repository-dir deps-edn-path deps-repo-tag aliases aot-default]
+(defn srcs [{:keys [repository-dir deps-edn-path deps-repo-tag aliases aot-default pool]
              :or {deps-repo-tag "@deps"}}]
   {:pre [(re-find #"^@" deps-repo-tag) deps-edn-path repository-dir]}
   (let [deps-edn-path (-> deps-edn-path fs/->path fs/absolute)
@@ -954,7 +973,8 @@
               :deps-repo-tag deps-repo-tag
               :basis basis
               :jar->lib jar->lib
-              :class->jar class->jar}]
+              :class->jar class->jar
+              :pool pool}]
     (gen-source-paths args)))
 
 (defn gen-namespace-loader
@@ -1011,12 +1031,14 @@
 (defn -main [& args]
   ;; binding [*print-length* 10
   ;;          *print-level* 3]
-  (let [cmd (first args)
+  (let [pool (Executors/newCachedThreadPool)
+        cmd (first args)
         cmd (keyword cmd)
         opts (apply hash-map (rest args))
         opts (into {} (map (fn [[k v]]
                              [(edn/read-string k) v]) opts))
         opts (-> opts
+                 (assoc :pool pool)
                  (update :aliases (fn [aliases] (-> aliases
                                                     (edn/read-string)
                                                     (#(mapv keyword %)))))
@@ -1028,4 +1050,7 @@
             :deps deps
             :srcs srcs
             :ns-loader gen-namespace-loader)]
-    (f opts)))
+    (try
+      (f opts)
+      (finally
+        (shutdown-pool pool 5000)))))

--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -588,6 +588,9 @@
     (clj-path? path) #{:clj}
     (cljs-path? path) #{:cljs}))
 
+(defn prun [f coll]
+  (run! deref (mapv #(future (f %)) coll)))
+
 (s/fdef ns-rules :args (s/cat :a (s/keys :req-un [::basis ::deps-edn-dir ::jar->lib ::deps-repo-tag ::deps-bazel]) :p (s/coll-of fs/path?)))
 (defn ns-rules
   "given a .clj path, return all rules for the file "
@@ -747,9 +750,8 @@
        (distinct)
        (sort-by (comp count str))
        (reverse)
-       (map (fn [dir]
-              (gen-dir args dir)))
-       (dorun)))
+       (prun (fn [dir]
+               (gen-dir args dir)))))
 
 (defn path->absolute
   [path deps-edn-path]
@@ -1028,4 +1030,5 @@
             :deps deps
             :srcs srcs
             :ns-loader gen-namespace-loader)]
-    (f opts)))
+    (f opts)
+    (shutdown-agents)))


### PR DESCRIPTION
much of the time in `bazel run //:gen_srcs` is IO and so can be parallelised for a significant speedup.  parallelising the calls to `gen-dir` speeds up my benchmark of `-main` from ~7s to 5s

the overall `bazel run //:gen_srcs` runtime drops from 9.7s to 7.2s (although these are quite variable).