### PR TITLE
Dump threads on test timeout

### DIFF
--- a/src/rules_clojure/testrunner.clj
+++ b/src/rules_clojure/testrunner.clj
@@ -1,6 +1,17 @@
 (ns rules-clojure.testrunner
   (:require [clojure.test])
+  (:import [sun.misc Signal SignalHandler]
+           [java.lang.management ManagementFactory])
   (:gen-class))
+
+(def old-handler
+  (Signal/handle
+    (Signal. "TERM")
+    (reify SignalHandler
+      (handle [_ signal]
+        (run! println (.dumpAllThreads (ManagementFactory/getThreadMXBean) true true))
+        (when-not (#{SignalHandler/SIG_DFL SignalHandler/SIG_IGN} old-handler)
+          (.handle old-handler signal))))))
 
 (defn -main [& args]
   (assert (string? (first args)) (print-str "first argument must be a string, got" args))


### PR DESCRIPTION
This uses sun.misc.Signal, which has been granted an [exemption](https://openjdk.org/jeps/260) for now.  It's important to _only_ hook SIGTERM and not general exits, which is why I'm not using a shutdown hook here.

There is a jnr-signals package, but I figured that bringing in more dependencies was a lot of work relative to just using seemingly safe sun.misc.Signal*

This is important for debugging _where_ in your test there's a timeout.