### PR TITLE
Add Gazelle Clojure plugin

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,2 +1,6 @@
 {:linters {:unused-binding {:exclude-destructured-keys-in-fn-args true
-                            :exclude-destructured-as true}}}
+                            :exclude-destructured-as true}
+           ;; Tests in this repo use `(:require [clojure.test :refer :all])`
+           ;; for the conventional shorthand; silence kondo's default warning.
+           :refer-all {:exclude #{clojure.test}}}
+ :lint-as {rules-clojure.gazelle-server-test/with-temp-dir clojure.core/with-open}}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bazel-*
 examples/gen_srcs_bench/src/
 examples/gen_srcs_bench/hyperfine.json
 .nrepl-port
+target/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,14 @@ bazel_dep(name = "rules_jvm_external", version = "6.8")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
 
+# Go + Gazelle for the Clojure Gazelle plugin (//gazelle).
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "gazelle", version = "0.47.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//gazelle:go.mod")
+use_repo(go_deps, "com_github_bazelbuild_buildtools")
+
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     name = "maven_deps",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -18,6 +18,7 @@
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
@@ -30,7 +31,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
-    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/source.json": "279625cafa5b63cc0a8ee8448d93bc5ac1431f6000c50414051173fd22a6df3c",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
@@ -50,6 +52,12 @@
     "https://bcr.bazel.build/modules/buildifier_prebuilt/8.5.1.2/source.json": "33e11b3bf11e39cb762480a7e6ea1d24d044636135cdd8b8e74b07ebcd3b8d8b",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
+    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
+    "https://bcr.bazel.build/modules/gazelle/0.47.0/MODULE.bazel": "b61bb007c4efad134aa30ee7f4a8e2a39b22aa5685f005edaa022fbd1de43ebc",
+    "https://bcr.bazel.build/modules/gazelle/0.47.0/source.json": "aeb2e5df14b7fb298625d75d08b9c65bdb0b56014c5eb89da9e5dd0572280ae6",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -63,6 +71,8 @@
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/source.json": "2326db2f6592578177751c3e1f74786b79382cd6008834c9d01ec865b9126a85",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -81,6 +91,8 @@
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
     "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
     "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
     "https://bcr.bazel.build/modules/protobuf/32.1/source.json": "bd2664e90875c0cd755d1d9b7a103a4b027893ac8eafa3bba087557ffc244ad4",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
@@ -106,11 +118,18 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/source.json": "85087982aca15f31307bd52698316b28faa31bd2c3095a41f456afec0131344c",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
+    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
+    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
+    "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
+    "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
@@ -149,6 +168,7 @@
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
@@ -181,12 +201,191 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//:extensions.bzl%deps": {
+      "general": {
+        "bzlTransitiveDigest": "bvuoUIbvdTWkMMsvL1iBExvuWHHwNiDnzYMHROZM29E=",
+        "usagesDigest": "4aiDt0BRo9LfGCQL8Q0nEFdUckZDEZJJdzrUaYRp3UA=",
+        "recordedFileInputs": {
+          "@@example-simple+//deps.edn": "7076e89823651e913d5ddc808fc084a22f46cacb8bf4ef5afef0e381c3b26b81"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "deps": {
+            "repoRuleId": "@@//rules:tools_deps.bzl%clojure_tools_deps",
+            "attributes": {
+              "repo_name": "deps",
+              "aliases": [
+                "dev",
+                "test"
+              ],
+              "clj_version": "1.11.1.1347",
+              "deps_edn": "@@example-simple+//:deps.edn",
+              "env": {},
+              "root_module_name": ""
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "useAllRepos": "REGULAR",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "rules_clojure",
+            ""
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "NFQjcZF+fAvf5fDH+pqsx4JrfzP9PuHBz6S6ZutIbnw=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "83fAvD/IQhfPED72intPfmIdI+xpPpsLz91YBSqaU+E=",
+        "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_provisioning_profiles": {
+            "repoRuleId": "@@rules_apple+//apple/internal:local_provisioning_profiles.bzl%provisioning_profile_repository",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_apple+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_apple+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_apple+",
+            "build_bazel_apple_support",
+            "apple_support+"
+          ],
+          [
+            "rules_apple+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_swift+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_swift+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_apple_support",
+            "apple_support+"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift_local_config",
+            "rules_swift++non_module_deps+build_bazel_rules_swift_local_config"
+          ]
+        ]
+      }
+    },
+    "@@rules_apple+//apple:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "4xtddSlWIQdtVNVuvOI62fJfQVETHZCVWFvYYwQHMR4=",
+        "usagesDigest": "M3VqFpeTCo4qmrNKGZw0dxBHvTYDrfV3cscGzlSAhQ4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "xctestrunner": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/xctestrunner/archive/b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6.tar.gz"
+              ],
+              "strip_prefix": "xctestrunner-b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6",
+              "sha256": "ae3a063c985a8633cb7eb566db21656f8db8eb9a0edb8c182312c7f0db53730d"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_apple+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "nvW/NrBXlAmiQw99EMGKkLaD2KbNp2mQDlxdfpr+0Ls=",
@@ -286,7 +485,331 @@
           ]
         ]
       }
+    },
+    "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "6axDCXf6fQoPav8hojnUBxGA0FAMqLvtpC1cRsisCdw=",
+        "usagesDigest": "mhACFnrdMv9Wi0Mt67bxocJqviRkDSV+Ee5Mqdj5akA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_apple_swift_protobuf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_grpc_grpc_swift": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_docc_symbolkit": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-docc-symbolkit/archive/refs/tags/swift-5.10-RELEASE.tar.gz"
+              ],
+              "sha256": "de1d4b6940468ddb53b89df7aa1a81323b9712775b0e33e8254fa0f6f7469a97",
+              "strip_prefix": "swift-docc-symbolkit-swift-5.10-RELEASE",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_docc_symbolkit/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_swift+//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "repoRuleId": "@@rules_swift+//swift/internal:swift_autoconfiguration.bzl%swift_autoconfiguration",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ]
+        ]
+      }
     }
   },
-  "facts": {}
+  "facts": {
+    "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "1.25.0": {
+        "aix_ppc64": [
+          "go1.25.0.aix-ppc64.tar.gz",
+          "e5234a7dac67bc86c528fe9752fc9d63557918627707a733ab4cac1a6faed2d4"
+        ],
+        "darwin_amd64": [
+          "go1.25.0.darwin-amd64.tar.gz",
+          "5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef"
+        ],
+        "darwin_arm64": [
+          "go1.25.0.darwin-arm64.tar.gz",
+          "544932844156d8172f7a28f77f2ac9c15a23046698b6243f633b0a0b00c0749c"
+        ],
+        "dragonfly_amd64": [
+          "go1.25.0.dragonfly-amd64.tar.gz",
+          "5ed3cf9a810a1483822538674f1336c06b51aa1b94d6d545a1a0319a48177120"
+        ],
+        "freebsd_386": [
+          "go1.25.0.freebsd-386.tar.gz",
+          "abea5d5c6697e6b5c224731f2158fe87c602996a2a233ac0c4730cd57bf8374e"
+        ],
+        "freebsd_amd64": [
+          "go1.25.0.freebsd-amd64.tar.gz",
+          "86e6fe0a29698d7601c4442052dac48bd58d532c51cccb8f1917df648138730b"
+        ],
+        "freebsd_arm": [
+          "go1.25.0.freebsd-arm.tar.gz",
+          "d90b78e41921f72f30e8bbc81d9dec2cff7ff384a33d8d8debb24053e4336bfe"
+        ],
+        "freebsd_arm64": [
+          "go1.25.0.freebsd-arm64.tar.gz",
+          "451d0da1affd886bfb291b7c63a6018527b269505db21ce6e14724f22ab0662e"
+        ],
+        "freebsd_riscv64": [
+          "go1.25.0.freebsd-riscv64.tar.gz",
+          "7b565f76bd8bda46549eeaaefe0e53b251e644c230577290c0f66b1ecdb3cdbe"
+        ],
+        "illumos_amd64": [
+          "go1.25.0.illumos-amd64.tar.gz",
+          "b1e1fdaab1ad25aa1c08d7a36c97d45d74b98b89c3f78c6d2145f77face54a2c"
+        ],
+        "linux_386": [
+          "go1.25.0.linux-386.tar.gz",
+          "8c602dd9d99bc9453b3995d20ce4baf382cc50855900a0ece5de9929df4a993a"
+        ],
+        "linux_amd64": [
+          "go1.25.0.linux-amd64.tar.gz",
+          "2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
+        ],
+        "linux_arm64": [
+          "go1.25.0.linux-arm64.tar.gz",
+          "05de75d6994a2783699815ee553bd5a9327d8b79991de36e38b66862782f54ae"
+        ],
+        "linux_armv6l": [
+          "go1.25.0.linux-armv6l.tar.gz",
+          "a5a8f8198fcf00e1e485b8ecef9ee020778bf32a408a4e8873371bfce458cd09"
+        ],
+        "linux_loong64": [
+          "go1.25.0.linux-loong64.tar.gz",
+          "cab86b1cf761b1cb3bac86a8877cfc92e7b036fc0d3084123d77013d61432afc"
+        ],
+        "linux_mips": [
+          "go1.25.0.linux-mips.tar.gz",
+          "d66b6fb74c3d91b9829dc95ec10ca1f047ef5e89332152f92e136cf0e2da5be1"
+        ],
+        "linux_mips64": [
+          "go1.25.0.linux-mips64.tar.gz",
+          "4082e4381a8661bc2a839ff94ba3daf4f6cde20f8fb771b5b3d4762dc84198a2"
+        ],
+        "linux_mips64le": [
+          "go1.25.0.linux-mips64le.tar.gz",
+          "70002c299ec7f7175ac2ef673b1b347eecfa54ae11f34416a6053c17f855afcc"
+        ],
+        "linux_mipsle": [
+          "go1.25.0.linux-mipsle.tar.gz",
+          "b00a3a39eff099f6df9f1c7355bf28e4589d0586f42d7d4a394efb763d145a73"
+        ],
+        "linux_ppc64": [
+          "go1.25.0.linux-ppc64.tar.gz",
+          "df166f33bd98160662560a72ff0b4ba731f969a80f088922bddcf566a88c1ec1"
+        ],
+        "linux_ppc64le": [
+          "go1.25.0.linux-ppc64le.tar.gz",
+          "0f18a89e7576cf2c5fa0b487a1635d9bcbf843df5f110e9982c64df52a983ad0"
+        ],
+        "linux_riscv64": [
+          "go1.25.0.linux-riscv64.tar.gz",
+          "c018ff74a2c48d55c8ca9b07c8e24163558ffec8bea08b326d6336905d956b67"
+        ],
+        "linux_s390x": [
+          "go1.25.0.linux-s390x.tar.gz",
+          "34e5a2e19f2292fbaf8783e3a241e6e49689276aef6510a8060ea5ef54eee408"
+        ],
+        "netbsd_386": [
+          "go1.25.0.netbsd-386.tar.gz",
+          "f8586cdb7aa855657609a5c5f6dbf523efa00c2bbd7c76d3936bec80aa6c0aba"
+        ],
+        "netbsd_amd64": [
+          "go1.25.0.netbsd-amd64.tar.gz",
+          "ae8dc1469385b86a157a423bb56304ba45730de8a897615874f57dd096db2c2a"
+        ],
+        "netbsd_arm": [
+          "go1.25.0.netbsd-arm.tar.gz",
+          "1ff7e4cc764425fc9dd6825eaee79d02b3c7cafffbb3691687c8d672ade76cb7"
+        ],
+        "netbsd_arm64": [
+          "go1.25.0.netbsd-arm64.tar.gz",
+          "e1b310739f26724216aa6d7d7208c4031f9ff54c9b5b9a796ddc8bebcb4a5f16"
+        ],
+        "openbsd_386": [
+          "go1.25.0.openbsd-386.tar.gz",
+          "4802a9b20e533da91adb84aab42e94aa56cfe3e5475d0550bed3385b182e69d8"
+        ],
+        "openbsd_amd64": [
+          "go1.25.0.openbsd-amd64.tar.gz",
+          "c016cd984bebe317b19a4f297c4f50def120dc9788490540c89f28e42f1dabe1"
+        ],
+        "openbsd_arm": [
+          "go1.25.0.openbsd-arm.tar.gz",
+          "a1e31d0bf22172ddde42edf5ec811ef81be43433df0948ece52fecb247ccfd8d"
+        ],
+        "openbsd_arm64": [
+          "go1.25.0.openbsd-arm64.tar.gz",
+          "343ea8edd8c218196e15a859c6072d0dd3246fbbb168481ab665eb4c4140458d"
+        ],
+        "openbsd_ppc64": [
+          "go1.25.0.openbsd-ppc64.tar.gz",
+          "694c14da1bcaeb5e3332d49bdc2b6d155067648f8fe1540c5de8f3cf8e157154"
+        ],
+        "openbsd_riscv64": [
+          "go1.25.0.openbsd-riscv64.tar.gz",
+          "aa510ad25cf54c06cd9c70b6d80ded69cb20188ac6e1735655eef29ff7e7885f"
+        ],
+        "plan9_386": [
+          "go1.25.0.plan9-386.tar.gz",
+          "46f8cef02086cf04bf186c5912776b56535178d4cb319cd19c9fdbdd29231986"
+        ],
+        "plan9_amd64": [
+          "go1.25.0.plan9-amd64.tar.gz",
+          "29b34391d84095e44608a228f63f2f88113a37b74a79781353ec043dfbcb427b"
+        ],
+        "plan9_arm": [
+          "go1.25.0.plan9-arm.tar.gz",
+          "0a047107d13ebe7943aaa6d54b1d7bbd2e45e68ce449b52915a818da715799c2"
+        ],
+        "solaris_amd64": [
+          "go1.25.0.solaris-amd64.tar.gz",
+          "9977f9e4351984364a3b2b78f8b88bfd1d339812356d5237678514594b7d3611"
+        ],
+        "windows_386": [
+          "go1.25.0.windows-386.zip",
+          "df9f39db82a803af0db639e3613a36681ab7a42866b1384b3f3a1045663961a7"
+        ],
+        "windows_amd64": [
+          "go1.25.0.windows-amd64.zip",
+          "89efb4f9b30812eee083cc1770fdd2913c14d301064f6454851428f9707d190b"
+        ],
+        "windows_arm64": [
+          "go1.25.0.windows-arm64.zip",
+          "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
+        ]
+      }
+    }
+  }
 }

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@gazelle//:def.bzl", "gazelle_binary")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gazelle_lib",
+    srcs = [
+        "configure.go",
+        "generate.go",
+        "lang.go",
+        "resolve.go",
+    ],
+    importpath = "github.com/griffinbank/rules_clojure/gazelle",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//gazelle/clojureconfig",
+        "//gazelle/clojureparser",
+        "@gazelle//config:go_default_library",
+        "@gazelle//label:go_default_library",
+        "@gazelle//language:go_default_library",
+        "@gazelle//repo:go_default_library",
+        "@gazelle//resolve:go_default_library",
+        "@gazelle//rule:go_default_library",
+    ],
+)
+
+go_test(
+    name = "gazelle_test",
+    srcs = [
+        "configure_test.go",
+        "generate_test.go",
+        "resolve_test.go",
+    ],
+    embed = [":gazelle_lib"],
+    deps = [
+        "//gazelle/clojureconfig",
+        "//gazelle/clojureparser",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@gazelle//config:go_default_library",
+        "@gazelle//label:go_default_library",
+        "@gazelle//rule:go_default_library",
+    ],
+)
+
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = [":gazelle_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/gazelle/clojureconfig/BUILD.bazel
+++ b/gazelle/clojureconfig/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "clojureconfig",
+    srcs = ["config.go"],
+    importpath = "github.com/griffinbank/rules_clojure/gazelle/clojureconfig",
+    visibility = ["//gazelle:__subpackages__"],
+)
+
+go_test(
+    name = "clojureconfig_test",
+    srcs = ["config_test.go"],
+    embed = [":clojureconfig"],
+)

--- a/gazelle/clojureconfig/config.go
+++ b/gazelle/clojureconfig/config.go
@@ -1,0 +1,132 @@
+// Package clojureconfig collects Gazelle directives for the Clojure plugin.
+// It holds raw directive values per package (rel → kv-map) and supports the
+// parent-fallback walk Gazelle's per-package config model implies. Semantic
+// interpretation of resolved values — basis assembly, label generation,
+// effective rule shape — belongs in the Clojure server; the trivial value-
+// string normalization needed for directive consumption (alias parsing,
+// trim-empty) lives here because every Go-side caller needs it.
+package clojureconfig
+
+import (
+	"path"
+	"strings"
+)
+
+// Directive name constants used in BUILD file comments.
+const (
+	ClojureExtensionDirective = "clojure_enabled"
+	ClojureDepsEdn            = "clojure_deps_edn"
+	ClojureDepsRepo           = "clojure_deps_repo"
+	ClojureAliases            = "clojure_aliases"
+
+	// rootModuleName is auto-discovered from MODULE.bazel; it isn't a
+	// user-facing directive but is stored under the same map.
+	rootModuleName = "_root_module_name"
+)
+
+// Configs maps package-relative paths to their raw directive values.
+// Lookup goes through Effective() which walks ancestors for inheritance.
+type Configs map[string]map[string]string
+
+// Effective returns the value for `key` at `rel`, falling back to ancestor
+// rels (parent dirs) and finally `dflt` when no override was set.
+func (cs Configs) Effective(rel, key, dflt string) string {
+	for {
+		if v, ok := cs[rel][key]; ok {
+			return v
+		}
+		if rel == "" {
+			return dflt
+		}
+		rel = path.Dir(rel)
+		if rel == "." {
+			rel = ""
+		}
+	}
+}
+
+// ExtensionEnabled returns whether the Clojure extension is active for rel,
+// honouring per-package `# gazelle:clojure_enabled false` overrides.
+// Defaults to true at the root.
+func (cs Configs) ExtensionEnabled(rel string) bool {
+	switch cs.Effective(rel, ClojureExtensionDirective, "true") {
+	case "false":
+		return false
+	default:
+		return true
+	}
+}
+
+// DepsRepo returns the deps repo tag for rel — default "@deps" at the root,
+// overridden by `# gazelle:clojure_deps_repo @other_deps` in any ancestor.
+func (cs Configs) DepsRepo(rel string) string {
+	return cs.Effective(rel, ClojureDepsRepo, "@deps")
+}
+
+// DepsEdn returns the workspace-relative deps.edn path captured at the root
+// during the initial Configure pass. Auto-discovered if no directive set.
+func (cs Configs) DepsEdn() string {
+	return cs.Effective("", ClojureDepsEdn, "")
+}
+
+// RootModuleName returns the bzlmod module(name=...) value, captured during
+// the root Configure pass by reading MODULE.bazel. Used to canonicalize
+// self-referencing labels (`@<root>//foo` → `@@//foo`) so generated rules
+// agree with the apparent-name view Bazel exposes to consumers.
+func (cs Configs) RootModuleName() string {
+	return cs.Effective("", rootModuleName, "")
+}
+
+// SetRootModuleName stashes the discovered bzlmod root module name on the
+// root config.
+func (cs Configs) SetRootModuleName(name string) {
+	if _, ok := cs[""]; !ok {
+		cs[""] = map[string]string{}
+	}
+	cs[""][rootModuleName] = name
+}
+
+// Aliases returns the parsed alias list from the root-level
+// `# gazelle:clojure_aliases` directive. Per-package alias overrides are
+// not supported (aliases feed the basis, which is computed once at init).
+func (cs Configs) Aliases() []string {
+	return ParseAliases(cs.Effective("", ClojureAliases, ""))
+}
+
+// Set stores a raw directive value on `rel`. Empty values are treated as
+// "unset" so a child config doesn't accidentally override its parent with
+// the zero value — Effective() falls through to the next ancestor.
+func (cs Configs) Set(rel, key, value string) {
+	if value == "" {
+		return
+	}
+	if _, ok := cs[rel]; !ok {
+		cs[rel] = map[string]string{}
+	}
+	cs[rel][key] = value
+}
+
+// AllDirectives returns the directive names Gazelle should recognize from
+// `# gazelle:<name> <value>` comments in BUILD files.
+func AllDirectives() []string {
+	return []string{
+		ClojureExtensionDirective,
+		ClojureDepsEdn,
+		ClojureDepsRepo,
+		ClojureAliases,
+	}
+}
+
+// ParseAliases splits a comma-separated alias string, trims whitespace,
+// and drops empty entries. strings.Split("", ",") returns [""], and a
+// naive split of "dev, test" leaves a leading space on the second entry
+// — both yield malformed keywords on the Clojure side.
+func ParseAliases(s string) []string {
+	out := []string{}
+	for _, raw := range strings.Split(s, ",") {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/gazelle/clojureconfig/config_test.go
+++ b/gazelle/clojureconfig/config_test.go
@@ -1,0 +1,97 @@
+package clojureconfig
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAliases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty", in: "", want: []string{}},
+		{name: "single", in: "dev", want: []string{"dev"}},
+		{name: "two", in: "dev,test", want: []string{"dev", "test"}},
+		{name: "trims whitespace", in: " dev , test ", want: []string{"dev", "test"}},
+		{name: "drops empty entries", in: ",,dev,,test,", want: []string{"dev", "test"}},
+		{name: "all empty", in: ",,,", want: []string{}},
+		{name: "colon-prefixed kept verbatim", in: ":dev", want: []string{":dev"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseAliases(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseAliases(%q) = %v; want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveWalksParentChain(t *testing.T) {
+	cs := Configs{
+		"":      {ClojureDepsRepo: "@root"},
+		"a":     {ClojureDepsRepo: "@a"},
+		"a/b/c": {ClojureDepsRepo: "@deep"},
+	}
+	cases := map[string]string{
+		"":        "@root",
+		"a":       "@a",
+		"a/b":     "@a",    // a/b unset → a
+		"a/b/c":   "@deep", // exact match
+		"a/b/c/d": "@deep", // child of c → deep
+		"x/y/z":   "@root", // unrelated → root default
+	}
+	for rel, want := range cases {
+		t.Run(rel, func(t *testing.T) {
+			got := cs.DepsRepo(rel)
+			if got != want {
+				t.Errorf("DepsRepo(%q) = %q; want %q", rel, got, want)
+			}
+		})
+	}
+}
+
+func TestEffectiveDefaultsWhenNothingSet(t *testing.T) {
+	cs := Configs{}
+	if got := cs.DepsRepo("anything"); got != "@deps" {
+		t.Errorf("DepsRepo on empty Configs = %q; want @deps default", got)
+	}
+}
+
+func TestExtensionEnabledFalseSticks(t *testing.T) {
+	cs := Configs{}
+	if !cs.ExtensionEnabled("") {
+		t.Error("default ExtensionEnabled = false; want true")
+	}
+	cs.Set("a", ClojureExtensionDirective, "false")
+	if cs.ExtensionEnabled("a") {
+		t.Error("ExtensionEnabled(a) after false override = true")
+	}
+	// Child inherits parent's false.
+	if cs.ExtensionEnabled("a/b") {
+		t.Error("child ExtensionEnabled = true; want inherited false")
+	}
+	// Sibling unaffected.
+	if !cs.ExtensionEnabled("other") {
+		t.Error("sibling ExtensionEnabled = false; want default true")
+	}
+}
+
+func TestAliasesParsesRootDirective(t *testing.T) {
+	cs := Configs{}
+	cs.Set("", ClojureAliases, "dev,test")
+	got := cs.Aliases()
+	if !reflect.DeepEqual(got, []string{"dev", "test"}) {
+		t.Errorf("Aliases() = %v; want [dev test]", got)
+	}
+}
+
+func TestSetRootModuleName(t *testing.T) {
+	cs := Configs{}
+	cs.SetRootModuleName("foo")
+	if got := cs.RootModuleName(); got != "foo" {
+		t.Errorf("RootModuleName = %q; want foo", got)
+	}
+}

--- a/gazelle/clojureparser/BUILD.bazel
+++ b/gazelle/clojureparser/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "clojureparser",
+    srcs = ["parser.go"],
+    importpath = "github.com/griffinbank/rules_clojure/gazelle/clojureparser",
+    visibility = ["//gazelle:__subpackages__"],
+)
+
+go_test(
+    name = "clojureparser_test",
+    srcs = [
+        "lifecycle_test.go",
+        "parser_test.go",
+    ],
+    embed = [":clojureparser"],
+)

--- a/gazelle/clojureparser/lifecycle_test.go
+++ b/gazelle/clojureparser/lifecycle_test.go
@@ -1,0 +1,117 @@
+package clojureparser
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubScript creates a temporary executable shell script with the given
+// content and returns its path. The script is removed on test cleanup.
+func stubScript(t *testing.T, content string) string {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	path := filepath.Join(t.TempDir(), "stub.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+content), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRunnerExchangeMarksDeadOnEOF(t *testing.T) {
+	// Script exits immediately after reading one line. The first exchange
+	// receives nothing back → unexpected EOF, runner.dead = true.
+	stub := stubScript(t, "read first\n")
+	runner, err := New(stub)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer runner.Shutdown()
+
+	if _, err := runner.Init(InitRequest{DepsEdnPath: "/dev/null"}); err == nil {
+		t.Fatal("first Init expected error from EOF on dying subprocess")
+	}
+	if !runner.dead {
+		t.Error("runner.dead = false after exchange failure; want true")
+	}
+
+	// Second call must short-circuit on the dead flag, not race the corpse.
+	_, err = runner.Parse(ParseRequest{Dir: "x"})
+	if err != ErrRunnerDead {
+		t.Errorf("second call err = %v; want ErrRunnerDead", err)
+	}
+}
+
+func TestRunnerShutdownIdempotent(t *testing.T) {
+	stub := stubScript(t, "cat\n")
+	runner, err := New(stub)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	runner.Shutdown()
+	runner.Shutdown() // must not panic, deadlock, or double-close
+}
+
+func TestRunnerShutdownOnNilReceiver(t *testing.T) {
+	var r *Runner
+	r.Shutdown() // must not panic
+}
+
+func TestInitRejectsMalformedJSON(t *testing.T) {
+	stub := stubScript(t, "read line\n"+`printf 'not json at all\n'`+"\n")
+	runner, err := New(stub)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer runner.Shutdown()
+	_, err = runner.Init(InitRequest{DepsEdnPath: "/dev/null"})
+	if err == nil {
+		t.Fatal("Init accepted malformed JSON; want error")
+	}
+	if !strings.Contains(err.Error(), "malformed init response") {
+		t.Errorf("err = %q; want 'malformed init response' marker", err.Error())
+	}
+}
+
+func TestInitRejectsErrorEnvelope(t *testing.T) {
+	stub := stubScript(t, "read line\n"+`printf '%s\n' '{"type":"error","message":"boom"}'`+"\n")
+	runner, err := New(stub)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer runner.Shutdown()
+	_, err = runner.Init(InitRequest{DepsEdnPath: "/dev/null"})
+	if err == nil {
+		t.Fatal("Init accepted error envelope; want error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("err = %q; want 'boom' message", err.Error())
+	}
+}
+
+func TestRunnerExchangeRoundTrip(t *testing.T) {
+	// Script echoes a canned response after reading one request.
+	resp := `{"type":"init","dep_ns_labels":{},"deps_bazel":{},"ignore_paths":[],"source_paths":[]}`
+	stub := stubScript(t, "read line\n"+`printf '%s\n' '`+resp+`'`+"\n")
+	runner, err := New(stub)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer runner.Shutdown()
+
+	got, err := runner.Init(InitRequest{DepsEdnPath: "/dev/null"})
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if got.Type != MsgTypeInit {
+		t.Errorf("Type = %q; want %q", got.Type, MsgTypeInit)
+	}
+
+	// Give the stub a moment to exit so the next test doesn't see a zombie.
+	time.Sleep(50 * time.Millisecond)
+}

--- a/gazelle/clojureparser/parser.go
+++ b/gazelle/clojureparser/parser.go
@@ -1,0 +1,425 @@
+// Package clojureparser is the Go client for the long-running Clojure
+// parser subprocess. It defines the JSON-line wire protocol (request and
+// response types) and Runner, which owns the subprocess lifecycle: start,
+// Init, Parse, Shutdown. Calls serialize on an internal mutex; any I/O
+// error marks the runner dead so subsequent calls short-circuit instead
+// of racing a corpse.
+package clojureparser
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// shutdownTimeout caps how long Shutdown waits for the subprocess to exit
+// after stdin close. If exceeded, the process is killed.
+const shutdownTimeout = 10 * time.Second
+
+// ErrRunnerDead is returned by Init/Parse after any prior send/receive
+// failure to short-circuit subsequent calls that would race a dead subprocess.
+var ErrRunnerDead = errors.New("clojureparser: runner is dead (prior failure)")
+
+// Request/response types for the JSON-line protocol with the Clojure parser subprocess.
+
+// Message type discriminators. Keep in sync with handle-request in
+// src/rules_clojure/gazelle_server.clj.
+const (
+	MsgTypeInit  = "init"
+	MsgTypeParse = "parse"
+	MsgTypeError = "error"
+)
+
+// Platform is one of the values reported by the parser. Promoting from a
+// plain string aids self-documentation in resolve.go: `ns.Requires[platform]`
+// vs `ns.Requires[string]` makes it clear what the keys are.
+type Platform = string
+
+// Platform enum values. Mirror gen_build.clj's clj-path? / cljs-path? / etc.
+const (
+	PlatformClj  Platform = "clj"
+	PlatformCljs Platform = "cljs"
+	PlatformJs   Platform = "js"
+)
+
+// InitRequest is the one-shot configuration sent at startup. The Clojure
+// server reads deps.edn, resolves transitive Maven coords against
+// RepositoryDir, and replies with InitResponse.
+type InitRequest struct {
+	Type           string   `json:"type"`
+	DepsEdnPath    string   `json:"deps_edn_path"`    // absolute path to deps.edn
+	RepositoryDir  string   `json:"repository_dir"`   // local Maven repo (~/.m2/repository)
+	DepsRepoTag    string   `json:"deps_repo_tag"`    // e.g. "@deps" — prefix for resolved labels
+	RootModuleName string   `json:"root_module_name"` // bzlmod module(name=...) for self-label canonicalization
+	Aliases        []string `json:"aliases"`          // deps.edn :aliases to activate
+}
+
+// InitResponse carries the resolved dep graph and configured paths. All
+// slice fields are emitted as JSON arrays (never null) so the Go caller can
+// range over them without a nil check.
+//
+// Note on DepNsLabels: the server emits a map keyed by platform string;
+// individual platform keys may be absent when the basis has no jars
+// providing that platform. resolve.go's lookup is guarded with a comma-ok
+// so a missing key becomes a no-op rather than a panic, but downstream
+// require-resolution will silently fail to find the dep — review the basis
+// if a require that should resolve doesn't.
+type InitResponse struct {
+	Type string `json:"type"`
+	// DepNsLabels maps platform → namespace-string → Bazel-label. Platform
+	// keys correspond to MsgType-style strings ("clj", "cljs"); inner keys
+	// are namespace symbols rendered as strings ("foo.bar").
+	DepNsLabels map[string]map[string]string `json:"dep_ns_labels"`
+	// DepsBazel mirrors the :bazel key from deps.edn (allows per-target
+	// override of generated deps). Other fields under :bazel are decoded
+	// and silently ignored — only :deps is consumed by resolve.go.
+	DepsBazel DepsBazel `json:"deps_bazel"`
+	// IgnorePaths are package-relative paths Gazelle should not generate
+	// rules for. SourcePaths is the same shape — paths included for
+	// generation, mirroring deps.edn :paths after alias merging.
+	IgnorePaths []string `json:"ignore_paths"`
+	SourcePaths []string `json:"source_paths"`
+}
+
+// DepsBazel carries the per-target dep overrides from deps.edn's :bazel
+// map. The Clojure server emits the whole :bazel map; this type only
+// names the field Resolve consumes (Deps), so other keys decode but stay
+// inert. Resolve adds the entries in Deps[<label>].Deps to the target's
+// :deps set after intra-repo + DepNsLabels resolution.
+type DepsBazel struct {
+	Deps map[string]DepsBazelTarget `json:"deps"`
+}
+
+// DepsBazelTarget is the per-target override block. Deps is a list of
+// fully-qualified Bazel labels that should be appended to the target's
+// generated :deps.
+type DepsBazelTarget struct {
+	Deps []string `json:"deps"`
+}
+
+// ParseRequest asks the server to parse one directory's Clojure files.
+// Files are basename-only (no Dir prefix). Dir is normally the
+// package-relative path; the server also accepts absolute paths (used by
+// tests / programmatic callers that don't have a workspace root).
+//
+// ClojureSubdirPaths lists workspace-relative subdir paths that
+// transitively contain Clojure content — populated bottom-up by Gazelle's
+// walk (via clojureLang.hasClojureContent). The server uses these to build
+// the __clj_lib / __clj_files rollup rules so the rule construction stays
+// in the Clojure side.
+type ParseRequest struct {
+	Type               string   `json:"type"`
+	Dir                string   `json:"dir"`
+	Files              []string `json:"files"`
+	ClojureSubdirPaths []string `json:"clojure_subdir_paths,omitempty"`
+}
+
+// RuleSpec is one fully-formed Bazel rule as decided by the Clojure-side
+// `gen-build/ns-rules`. Kind names the macro to emit ("clojure_library",
+// "clojure_test", "clojure_binary", "java_library"); Attrs carries the
+// kwargs to set on it. The `deps` attr is intentionally absent — Gazelle's
+// Resolve phase fills that in once the cross-package index is built.
+type RuleSpec struct {
+	Kind  string                 `json:"kind"`
+	Attrs map[string]interface{} `json:"attrs"`
+}
+
+// NamespaceInfo is the parser's per-namespace report. Multiple files with
+// the same basename (e.g. webauthn.clj + webauthn.cljs) collapse into one
+// NamespaceInfo with Platforms reflecting which extensions were present.
+//
+// The :deps on each clojure_library Rule already include the static parts
+// gen-build/ns-rules merges (org_clojure_clojure + clojure-library-args +
+// ns-library-meta + pre-resolved import-deps / gen-class-deps). Resolve
+// seeds depSet from those and adds only what needs the cross-package
+// index (intra-repo lookup, DepNsLabels per-platform, per-target
+// deps_bazel overrides).
+//
+// Error/Ns are not formally a sum type. Either Error is non-empty (fatal,
+// caller must abort) or Ns names a real namespace. JS-only groups are the
+// exception: Ns is empty and Requires is absent because Resolve never
+// reads them for kinds other than clojure_library.
+type NamespaceInfo struct {
+	// Ns is the namespace symbol from the (ns ...) form, e.g. "foo.core".
+	// Empty for JS-only groups; never read in that case (Resolve short-
+	// circuits on Kind != "clojure_library").
+	Ns string `json:"ns"`
+	// File is the basename of the primary file: the .clj if present, else
+	// the .cljs (Clojure groups), or the first .js (JS-only groups). Other
+	// files in the group are not surfaced individually.
+	File string `json:"file"`
+	// Requires maps platform → required-namespace list. Per-platform entries
+	// may be absent if that platform has no requires; the map itself is
+	// absent for JS-only groups (Resolve never reads it for java_library).
+	Requires map[Platform][]string `json:"requires,omitempty"`
+	// Platforms is a non-empty subset of {"clj","cljs","js"} naming which
+	// platforms this group produces output for. Set by the server's
+	// ext->platforms helper (clj/cljs/cljc → clj/cljs sets) and hardcoded
+	// to ["js"] for JS-only groups.
+	Platforms []Platform `json:"platforms"`
+	// Rules is the set of Bazel rules to emit for this namespace group,
+	// pre-constructed by gen-build/ns-rules. In practice ns-rules emits
+	// at most one clojure_library per group; Resolve attaches deps to
+	// every clojure_library it sees.
+	Rules []RuleSpec `json:"rules"`
+	// Error is non-empty when the Clojure server failed to parse this file
+	// group. The caller MUST treat this as fatal — silently dropping the
+	// entry would cause Gazelle to delete existing rules.
+	Error string `json:"error,omitempty"`
+}
+
+// ParseResponse wraps the per-group NamespaceInfo entries plus the
+// directory-level rollup rules (__clj_lib / __clj_files). The rollup specs
+// already incorporate ClojureSubdirPaths from the request, so the Go side
+// just translates them into *rule.Rule without further bookkeeping.
+type ParseResponse struct {
+	Type        string          `json:"type"`
+	Namespaces  []NamespaceInfo `json:"namespaces"`
+	RollupRules []RuleSpec      `json:"rollup_rules,omitempty"`
+}
+
+// Runner manages a Clojure parser subprocess, communicating over JSON lines
+// on stdin/stdout. Safe for concurrent use: Init, Parse, and Shutdown all
+// serialize on an internal mutex.
+type Runner struct {
+	cmd      *exec.Cmd
+	stdin    io.WriteCloser
+	stdout   *bufio.Scanner
+	mu       sync.Mutex // serializes all operations (exchange round-trips and Shutdown)
+	dead     bool       // set after any I/O failure; subsequent calls short-circuit
+	shutdown bool       // set by Shutdown to make it idempotent
+}
+
+// New starts the parser subprocess and returns a Runner.
+// Pass a single argument for a script/binary, or multiple for e.g. "java", "-jar", "path.jar".
+func New(binaryPath string, args ...string) (*Runner, error) {
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Stderr = os.Stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("clojureparser: stdin pipe: %w", err)
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("clojureparser: stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		return nil, fmt.Errorf("clojureparser: start %s: %w", binaryPath, err)
+	}
+
+	scanner := bufio.NewScanner(stdoutPipe)
+	// Allow up to 10 MB lines (dep_ns_labels can be large).
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	return &Runner{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: scanner,
+	}, nil
+}
+
+// Init sends an init request and reads the init response. Holds the
+// internal mutex for the full round-trip; marks the runner dead on any I/O
+// failure so subsequent calls short-circuit via ErrRunnerDead. Single
+// json.Unmarshal pass into a Message-carrying superset of InitResponse:
+// when the server replies with {type:error,message:...}, the Message
+// field captures it; on a normal init response Message is "" and the rest
+// of the struct decodes typed fields directly.
+func (r *Runner) Init(req InitRequest) (*InitResponse, error) {
+	req.Type = MsgTypeInit
+	data, err := r.exchange(req)
+	if err != nil {
+		return nil, err
+	}
+	var resp initEnvelope
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("clojureparser: malformed init response (%w): %s", err, jsonErrorContext(data, err))
+	}
+	if resp.Type == MsgTypeError {
+		return nil, fmt.Errorf("clojureparser: server error: %s", resp.Message)
+	}
+	return &resp.InitResponse, nil
+}
+
+// Parse sends a parse request and reads the parse response. Same
+// concurrency / dead-on-failure / single-unmarshal-with-error-envelope
+// semantics as Init.
+func (r *Runner) Parse(req ParseRequest) (*ParseResponse, error) {
+	req.Type = MsgTypeParse
+	data, err := r.exchange(req)
+	if err != nil {
+		return nil, err
+	}
+	var resp parseEnvelope
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("clojureparser: malformed parse response (%w): %s", err, jsonErrorContext(data, err))
+	}
+	if resp.Type == MsgTypeError {
+		return nil, fmt.Errorf("clojureparser: server error: %s", resp.Message)
+	}
+	return &resp.ParseResponse, nil
+}
+
+// initEnvelope / parseEnvelope decode the {type, message?, ...payload} wire
+// shape in a single json.Unmarshal pass. The Message field is captured
+// from error responses; on success it's empty and InitResponse/Parse-
+// Response carries the typed payload. Embedding rather than composing
+// keeps the JSON shape identical to the bare response types — Go's
+// encoding/json walks embedded struct fields as if they were inline.
+type initEnvelope struct {
+	Message string `json:"message,omitempty"`
+	InitResponse
+}
+
+type parseEnvelope struct {
+	Message string `json:"message,omitempty"`
+	ParseResponse
+}
+
+// exchange sends a request and reads one response line, holding the mutex
+// across the full round-trip. Marks the runner dead on any I/O failure so
+// subsequent calls short-circuit instead of racing a corpse.
+func (r *Runner) exchange(req interface{}) ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.dead {
+		return nil, ErrRunnerDead
+	}
+	if err := r.send(req); err != nil {
+		r.dead = true
+		return nil, err
+	}
+	data, err := r.receive()
+	if err != nil {
+		r.dead = true
+		return nil, err
+	}
+	return data, nil
+}
+
+// jsonErrorContext extracts a readable window from `data` around a JSON
+// parse error. When err is a *json.SyntaxError, the window is centered on
+// the byte offset; otherwise it falls back to a leading prefix.
+func jsonErrorContext(data []byte, err error) string {
+	const window = 200
+	if syn, ok := err.(*json.SyntaxError); ok {
+		off := int(syn.Offset)
+		start := off - window/2
+		if start < 0 {
+			start = 0
+		}
+		end := start + window
+		if end > len(data) {
+			end = len(data)
+		}
+		prefix := "..."
+		if start == 0 {
+			prefix = ""
+		}
+		suffix := "..."
+		if end == len(data) {
+			suffix = ""
+		}
+		return fmt.Sprintf("at offset %d: %s%s%s", off, prefix, string(data[start:end]), suffix)
+	}
+	if len(data) <= window {
+		return string(data)
+	}
+	return string(data[:window]) + "..."
+}
+
+// Shutdown closes stdin, then waits up to shutdownTimeout for the subprocess
+// to exit. Kills the process on timeout. Idempotent and safe on nil receiver.
+func (r *Runner) Shutdown() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.shutdown {
+		return
+	}
+	r.shutdown = true
+
+	if r.stdin != nil {
+		_ = r.stdin.Close()
+	}
+	if r.cmd == nil {
+		return
+	}
+
+	// Wait in a goroutine so we can apply a timeout. cmd.Wait is not
+	// cancellable, but Process.Kill unblocks it.
+	done := make(chan error, 1)
+	go func() { done <- r.cmd.Wait() }()
+	select {
+	case err := <-done:
+		// Clean EOF exit on stdin close is common (server reads EOF and
+		// stops). Don't spam the log unless the exit was unexpected.
+		if err != nil && r.cmd.ProcessState != nil && !r.cmd.ProcessState.Success() {
+			log.Printf("clojureparser: subprocess exit: %v (state=%s)", err, r.cmd.ProcessState)
+		}
+	case <-time.After(shutdownTimeout):
+		log.Printf("clojureparser: subprocess did not exit within %s after stdin close, killing", shutdownTimeout)
+		if r.cmd.Process != nil {
+			if killErr := r.cmd.Process.Kill(); killErr != nil {
+				log.Printf("clojureparser: kill failed: %v (process may already be reaped)", killErr)
+			}
+		}
+		<-done // reap the killed process
+	}
+}
+
+func (r *Runner) send(v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("clojureparser: marshal: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := r.stdin.Write(data); err != nil {
+		return fmt.Errorf("clojureparser: write: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) receive() ([]byte, error) {
+	if !r.stdout.Scan() {
+		if err := r.stdout.Err(); err != nil {
+			return nil, fmt.Errorf("clojureparser: read: %w", err)
+		}
+		// Include subprocess exit info when available — debugging "why did my
+		// BUILD silently empty?" is far harder without it.
+		exit := r.processExitInfo()
+		return nil, fmt.Errorf("clojureparser: unexpected EOF from subprocess%s", exit)
+	}
+	// Bytes() returns a slice backed by the scanner's internal buffer that
+	// is invalidated by the next Scan() call. The only callers are Init
+	// and Parse, both of which json.Unmarshal the slice before releasing
+	// the mutex (no opportunity for another Scan()), so the lifetime is
+	// safe by construction of the call sites. receive() stays unexported
+	// so the contract can't be violated from outside the package.
+	return r.stdout.Bytes(), nil
+}
+
+// processExitInfo returns a short " (exit=...)" suffix if the subprocess has
+// already exited, or "" otherwise. Called from receive() and Shutdown(),
+// both of which hold the mutex; the comment is for readers of the call
+// site, not a contract about external use.
+func (r *Runner) processExitInfo() string {
+	if r.cmd == nil || r.cmd.ProcessState == nil {
+		return ""
+	}
+	return fmt.Sprintf(" (exit=%s)", r.cmd.ProcessState)
+}

--- a/gazelle/clojureparser/parser_test.go
+++ b/gazelle/clojureparser/parser_test.go
@@ -1,0 +1,203 @@
+package clojureparser
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realRunnerFixture starts a Runner backed by the real Clojure parser
+// deploy jar. Skips the test cleanly if the jar or `java` aren't
+// available (clean CI without a prior `bazel build`) — unless
+// GAZELLE_INTEGRATION_TEST_REQUIRED=1, in which case the same conditions
+// cause a Fatal. CI sets the env var so a missing fixture doesn't
+// silently zero-cover the integration path.
+//
+// Returns the Runner + the workspace-relative path of the fixture
+// deps.edn the caller can pass through InitRequest.
+func realRunnerFixture(t *testing.T) (*Runner, string) {
+	t.Helper()
+	required := os.Getenv("GAZELLE_INTEGRATION_TEST_REQUIRED") == "1"
+	skipOrFail := func(format string, args ...interface{}) {
+		t.Helper()
+		if required {
+			t.Fatalf(format, args...)
+		}
+		t.Skipf(format, args...)
+	}
+
+	deployJar := os.Getenv("GAZELLE_SERVER_JAR")
+	if deployJar == "" {
+		wsRoot := findWorkspaceRoot(t, required)
+		deployJar = filepath.Join(wsRoot, "bazel-bin/src/rules_clojure/gazelle_server_deploy.jar")
+	}
+	if _, err := os.Stat(deployJar); err != nil {
+		skipOrFail("deploy jar not found at %s (run: bazel build //src/rules_clojure:gazelle_server_deploy.jar, or set GAZELLE_SERVER_JAR)", deployJar)
+	}
+	if _, err := exec.LookPath("java"); err != nil {
+		skipOrFail("java not found on PATH")
+	}
+
+	// Minimal fixture deps.edn + one .clj file the parse tests can target.
+	depsEdn := filepath.Join(t.TempDir(), "deps.edn")
+	srcDir := filepath.Join(filepath.Dir(depsEdn), "src", "my")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", srcDir, err)
+	}
+	if err := os.WriteFile(depsEdn, []byte(`{:deps {org.clojure/clojure {:mvn/version "1.12.1"}} :paths ["src"]}`), 0644); err != nil {
+		t.Fatalf("write %s: %v", depsEdn, err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "app.clj"), []byte(`(ns my.app (:require [clojure.string :as str]))`), 0644); err != nil {
+		t.Fatalf("write app.clj: %v", err)
+	}
+
+	runner, err := New("java", "-jar", deployJar)
+	if err != nil {
+		skipOrFail("could not start parser: %v", err)
+	}
+	t.Cleanup(runner.Shutdown)
+	return runner, depsEdn
+}
+
+// findWorkspaceRoot walks up from the test's cwd looking for WORKSPACE
+// (the Bazel workspace marker) so we can resolve the deploy jar at the
+// standard bazel-bin path. Skips the test if no workspace is found,
+// unless required=true (CI mode) in which case it fatals.
+func findWorkspaceRoot(t *testing.T, required bool) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "WORKSPACE")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			if required {
+				t.Fatal("GAZELLE_INTEGRATION_TEST_REQUIRED=1 but no WORKSPACE found")
+			}
+			t.Skip("could not find WORKSPACE root")
+		}
+		dir = parent
+	}
+}
+
+// initRequestFor builds an InitRequest pointing at the fixture deps.edn
+// + the host's local Maven cache (the real parser needs to resolve
+// transitive coords from there).
+func initRequestFor(depsEdn string) InitRequest {
+	return InitRequest{
+		DepsEdnPath:   depsEdn,
+		RepositoryDir: filepath.Join(os.Getenv("HOME"), ".m2", "repository"),
+		DepsRepoTag:   "@deps",
+		Aliases:       []string{},
+	}
+}
+
+func TestInitRoundTrip(t *testing.T) {
+	runner, depsEdn := realRunnerFixture(t)
+
+	resp, err := runner.Init(initRequestFor(depsEdn))
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if resp.Type != MsgTypeInit {
+		t.Errorf("expected type %q, got %q", MsgTypeInit, resp.Type)
+	}
+	if len(resp.SourcePaths) == 0 {
+		t.Errorf("expected at least one source path, got empty")
+	}
+	if resp.IgnorePaths == nil {
+		t.Error("ignore_paths is nil; expected non-nil slice")
+	}
+	if _, ok := resp.DepNsLabels[PlatformClj]; !ok {
+		t.Errorf("missing dep_ns_labels platform %q", PlatformClj)
+	}
+	if _, ok := resp.DepNsLabels[PlatformCljs]; !ok {
+		t.Errorf("missing dep_ns_labels platform %q", PlatformCljs)
+	}
+}
+
+func TestParseRoundTrip(t *testing.T) {
+	runner, depsEdn := realRunnerFixture(t)
+
+	if _, err := runner.Init(initRequestFor(depsEdn)); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	resp, err := runner.Parse(ParseRequest{
+		Dir:   filepath.Join(filepath.Dir(depsEdn), "src", "my"),
+		Files: []string{"app.clj"},
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if resp.Type != MsgTypeParse {
+		t.Errorf("expected type %q, got %q", MsgTypeParse, resp.Type)
+	}
+	if len(resp.Namespaces) != 1 {
+		t.Fatalf("expected 1 namespace, got %d", len(resp.Namespaces))
+	}
+	ns := resp.Namespaces[0]
+	if ns.Ns != "my.app" {
+		t.Errorf("expected ns my.app, got %q", ns.Ns)
+	}
+	if ns.File != "app.clj" {
+		t.Errorf("expected file app.clj, got %q", ns.File)
+	}
+	cljReqs, ok := ns.Requires[PlatformClj]
+	if !ok || len(cljReqs) != 1 || cljReqs[0] != "clojure.string" {
+		t.Errorf("expected requires {%q: [clojure.string]}, got %v", PlatformClj, ns.Requires)
+	}
+	foundClj := false
+	for _, p := range ns.Platforms {
+		if p == PlatformClj {
+			foundClj = true
+			break
+		}
+	}
+	if !foundClj {
+		t.Errorf("platforms = %v; want %q present", ns.Platforms, PlatformClj)
+	}
+}
+
+func TestInitRequestJSON(t *testing.T) {
+	req := InitRequest{
+		Type:          MsgTypeInit,
+		DepsEdnPath:   "/repo/deps.edn",
+		RepositoryDir: "/repo",
+		DepsRepoTag:   "@deps",
+		Aliases:       []string{"dev", "test"},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Assert against the literal byte stream so the snake_case JSON tags
+	// (deps_edn_path / repository_dir / deps_repo_tag / root_module_name /
+	// aliases) stay locked in — the Clojure server keys on these names.
+	for _, key := range []string{
+		`"type"`, `"deps_edn_path"`, `"repository_dir"`, `"deps_repo_tag"`,
+		`"root_module_name"`, `"aliases"`,
+	} {
+		if !strings.Contains(string(data), key) {
+			t.Errorf("marshalled InitRequest missing %s; got %s", key, data)
+		}
+	}
+	// Round-trip the discriminator separately so a tag-name regression
+	// surfaces with the actual offending value, not just a missing field.
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["type"] != MsgTypeInit {
+		t.Errorf("type round-trip = %v; want %q", decoded["type"], MsgTypeInit)
+	}
+}

--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -1,0 +1,158 @@
+// configure.go implements Gazelle's Configurer interface (RegisterFlags,
+// CheckFlags, KnownDirectives, Configure). Gazelle calls Configure(c, rel, f)
+// once per package as it walks the repo, passing each BUILD file's directives.
+// This file collects those directives into clojureconfig.Configs (a per-rel
+// map), auto-discovers the workspace-root deps.edn + bzlmod module name on
+// the first call, and triggers startParser when the root package is
+// configured. The parser subprocess is started with the root-level config
+// values (deps.edn path, deps-repo tag, aliases, etc.) and lives for the
+// duration of the Gazelle run.
+package gazelle
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureconfig"
+	"github.com/griffinbank/rules_clojure/gazelle/clojureparser"
+)
+
+// moduleNameRe matches `module(name = "...")` in MODULE.bazel — the canonical
+// bzlmod declaration. Doesn't parse Starlark, so a commented-out `module(...)`
+// line will match; in practice Buildifier formats MODULE.bazel and the
+// canonical call sits at the top of file, so this is acceptable.
+// The regex accepts mismatched single/double quotes (e.g. open " close ');
+// Buildifier always emits double quotes so this never matters in practice.
+var moduleNameRe = regexp.MustCompile(`module\(\s*name\s*=\s*["']([^"']+)["']`)
+
+// readRootModuleName extracts the bzlmod root module name from MODULE.bazel
+// at repoRoot. Returns "" only when MODULE.bazel is genuinely missing
+// (legacy WORKSPACE projects) or has no module() call. Any other read error
+// is fatal — silently treating an unreadable MODULE.bazel as "no module"
+// would skip self-label canonicalization and produce subtly wrong labels.
+func readRootModuleName(repoRoot string) string {
+	path := filepath.Join(repoRoot, "MODULE.bazel")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		log.Fatalf("clojure: read %s: %v", path, err)
+	}
+	m := moduleNameRe.FindSubmatch(data)
+	if m == nil {
+		return ""
+	}
+	return string(m[1])
+}
+
+func (*clojureLang) RegisterFlags(_ *flag.FlagSet, _ string, _ *config.Config) {}
+
+func (*clojureLang) CheckFlags(_ *flag.FlagSet, _ *config.Config) error {
+	return nil
+}
+
+func (*clojureLang) KnownDirectives() []string {
+	return clojureconfig.AllDirectives()
+}
+
+func (l *clojureLang) Configure(c *config.Config, rel string, f *rule.File) {
+	var configs clojureconfig.Configs
+	switch raw := c.Exts[languageName].(type) {
+	case nil:
+		configs = make(clojureconfig.Configs)
+		c.Exts[languageName] = configs
+		// Auto-discover root deps.edn + bzlmod module name on first call.
+		// Configure visits the root before any subpackage, so this fires
+		// exactly once.
+		depsPath := filepath.Join(c.RepoRoot, "deps.edn")
+		if _, err := os.Stat(depsPath); err == nil {
+			configs.Set("", clojureconfig.ClojureDepsEdn, depsPath)
+		}
+		if name := readRootModuleName(c.RepoRoot); name != "" {
+			configs.SetRootModuleName(name)
+		}
+	case clojureconfig.Configs:
+		configs = raw
+	default:
+		log.Fatalf("clojure: c.Exts[%q] is %T; expected clojureconfig.Configs (plugin conflict?)", languageName, raw)
+	}
+
+	// Record raw directive values for this package. clojure_deps_edn is
+	// stored absolute so startParser doesn't have to know about RepoRoot.
+	if f != nil {
+		for _, d := range f.Directives {
+			switch d.Key {
+			case clojureconfig.ClojureDepsEdn:
+				configs.Set(rel, d.Key, filepath.Join(c.RepoRoot, d.Value))
+			case clojureconfig.ClojureExtensionDirective,
+				clojureconfig.ClojureDepsRepo,
+				clojureconfig.ClojureAliases:
+				configs.Set(rel, d.Key, d.Value)
+			}
+		}
+	}
+
+	// Start the parser on the first Configure (root package). Gazelle's
+	// walk visits the root before any subpackage, so this fires before any
+	// GenerateRules call.
+	if rel == "" && l.session == nil && configs.DepsEdn() != "" {
+		l.startParser(c.RepoRoot, configs)
+	}
+}
+
+func (l *clojureLang) startParser(repoRoot string, configs clojureconfig.Configs) {
+	binaryPath := os.Getenv("GAZELLE_CLOJURE_PARSER")
+	if binaryPath == "" {
+		binaryPath = filepath.Join(repoRoot, "bazel-bin/src/rules_clojure/gazelle_server")
+	}
+
+	// Parser failures must fail loudly: a silent "log + continue" produces an
+	// empty GenerateResult per directory, which Gazelle interprets as "delete
+	// all existing rules". A green run that scorches the build graph is worse
+	// than a noisy exit.
+	runner, err := clojureparser.New(binaryPath)
+	if err != nil {
+		log.Fatalf("clojure: failed to start parser at %s: %v\n"+
+			"hint: run `bazel build //src/rules_clojure:gazelle_server` first, "+
+			"or set GAZELLE_CLOJURE_PARSER to a built binary.", binaryPath, err)
+	}
+
+	// Maven repository path: env override → $HOME/.m2/repository default.
+	// The env knob lets CI/containers/Maven-custom-repo setups point at a
+	// pre-populated cache without having to symlink into the runner's HOME.
+	repositoryDir := os.Getenv("CLOJURE_MAVEN_REPOSITORY")
+	if repositoryDir == "" {
+		repositoryDir = filepath.Join(os.Getenv("HOME"), ".m2", "repository")
+	}
+	rootDepsRepo := configs.DepsRepo("")
+	aliases := configs.Aliases()
+
+	resp, err := runner.Init(clojureparser.InitRequest{
+		DepsEdnPath:    configs.DepsEdn(),
+		RepositoryDir:  repositoryDir,
+		DepsRepoTag:    rootDepsRepo,
+		RootModuleName: configs.RootModuleName(),
+		Aliases:        aliases,
+	})
+	if err != nil {
+		runner.Shutdown()
+		log.Fatalf("clojure: parser init failed: %v\n"+
+			"hint: check deps.edn at %s parses and all aliases (%v) exist.",
+			err, configs.DepsEdn(), aliases)
+	}
+
+	l.session = &parserSession{
+		runner:      runner,
+		initResp:    resp,
+		depsRepoTag: rootDepsRepo,
+	}
+	log.Printf("clojure: parser started (source_paths=%v, ignore_paths=%v, dep_ns_labels clj=%d cljs=%d)",
+		resp.SourcePaths, resp.IgnorePaths, len(resp.DepNsLabels["clj"]), len(resp.DepNsLabels["cljs"]))
+}

--- a/gazelle/configure_test.go
+++ b/gazelle/configure_test.go
@@ -1,0 +1,109 @@
+package gazelle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureconfig"
+)
+
+// configureRoot drives the root-package Configure with a fixture deps.edn +
+// MODULE.bazel and returns the populated Configs and clojureLang.
+func configureRoot(t *testing.T, modContent string) (clojureconfig.Configs, *clojureLang) {
+	t.Helper()
+	dir := t.TempDir()
+	if modContent != "" {
+		if err := os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte(modContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// deps.edn presence triggers ClojureDepsEdn auto-discovery but Configure
+	// only calls startParser when DepsEdn() is non-empty. We deliberately
+	// skip startParser by NOT writing a deps.edn — startParser would shell
+	// out and fail in tests. Configure's pre-startParser bookkeeping is
+	// what we exercise here.
+	c := &config.Config{
+		RepoRoot: dir,
+		Exts:     map[string]interface{}{},
+	}
+	l := &clojureLang{
+		ruleNs:            map[string]string{},
+		hasClojureContent: map[string]bool{},
+	}
+	l.Configure(c, "", nil)
+	configs, ok := c.Exts[languageName].(clojureconfig.Configs)
+	if !ok {
+		t.Fatalf("Configure did not populate Exts[%q]; got %T", languageName, c.Exts[languageName])
+	}
+	return configs, l
+}
+
+func TestConfigureAutoDiscoversModuleName(t *testing.T) {
+	configs, _ := configureRoot(t, `module(name = "my_module", version = "0.1.0")`)
+	if got := configs.RootModuleName(); got != "my_module" {
+		t.Errorf("RootModuleName = %q; want my_module", got)
+	}
+}
+
+func TestConfigureNoModuleBazel(t *testing.T) {
+	configs, _ := configureRoot(t, "")
+	if got := configs.RootModuleName(); got != "" {
+		t.Errorf("RootModuleName = %q; want \"\" (legacy WORKSPACE projects)", got)
+	}
+}
+
+func TestConfigureNoDepsEdnSkipsParser(t *testing.T) {
+	_, l := configureRoot(t, "")
+	if l.session != nil {
+		t.Errorf("session populated despite missing deps.edn; want nil")
+	}
+}
+
+func TestConfigureRespectsExtensionDisableDirective(t *testing.T) {
+	dir := t.TempDir()
+	c := &config.Config{RepoRoot: dir, Exts: map[string]interface{}{}}
+	l := &clojureLang{ruleNs: map[string]string{}, hasClojureContent: map[string]bool{}}
+	// Root Configure.
+	l.Configure(c, "", nil)
+	// Sub-package Configure with `# gazelle:clojure_extension false`.
+	f := &rule.File{
+		Directives: []rule.Directive{
+			{Key: clojureconfig.ClojureExtensionDirective, Value: "false"},
+		},
+	}
+	l.Configure(c, "src/disabled", f)
+	configs := c.Exts[languageName].(clojureconfig.Configs)
+	if configs.ExtensionEnabled("src/disabled") {
+		t.Error("ExtensionEnabled(src/disabled) = true; want false after directive")
+	}
+	if !configs.ExtensionEnabled("src/enabled") {
+		t.Error("ExtensionEnabled(src/enabled) = false; want true (no directive there)")
+	}
+}
+
+func TestConfigureRespectsAliasDirectiveAtRoot(t *testing.T) {
+	dir := t.TempDir()
+	c := &config.Config{RepoRoot: dir, Exts: map[string]interface{}{}}
+	l := &clojureLang{ruleNs: map[string]string{}, hasClojureContent: map[string]bool{}}
+	f := &rule.File{
+		Directives: []rule.Directive{
+			{Key: clojureconfig.ClojureAliases, Value: ":dev,:test"},
+		},
+	}
+	l.Configure(c, "", f)
+	configs := c.Exts[languageName].(clojureconfig.Configs)
+	got := configs.Aliases()
+	want := []string{":dev", ":test"}
+	if len(got) != len(want) {
+		t.Fatalf("Aliases() = %v; want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Aliases()[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -1,0 +1,318 @@
+// generate.go implements Gazelle's RuleGenerator interface (GenerateRules,
+// Fix — Kinds + Loads live in lang.go). Gazelle calls GenerateRules(args)
+// per package after Configure. This file filters the package's files by
+// extension, computes which subdirs have Clojure content for the rollup
+// (`__clj_lib` / `__clj_files`), RPCs the Clojure parser with the file list
+// + subdir paths, and translates each returned `{kind, attrs}` rule spec
+// into a Gazelle *rule.Rule via buildRule + applyAttr.
+//
+// All rule construction decisions (AOT, test attrs, library shape, JS
+// fallback, rollup composition) live Clojure-side in rules-clojure.gen-build.
+// This file is the wire-format translator + the Gazelle integration layer;
+// it doesn't decide what a clojure_library should look like.
+package gazelle
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureconfig"
+	"github.com/griffinbank/rules_clojure/gazelle/clojureparser"
+)
+
+// validRuleKinds is the closed set of rule kinds the Clojure server is
+// allowed to emit. A Kind outside this set means the server is buggy or
+// out-of-sync with this Go plugin; emitting it via rule.NewRule would
+// produce a BUILD file Bazel can't load.
+var validRuleKinds = map[string]bool{
+	"clojure_library": true,
+	"clojure_test":    true,
+	"clojure_binary":  true,
+	"java_library":    true,
+	"filegroup":       true,
+}
+
+// clojureSourceExts are the Clojure-side extensions (.clj/.cljs/.cljc).
+// JS is handled separately because it groups into java_library targets, not
+// into the recursive subdir-has-Clojure rollup check.
+var clojureSourceExts = map[string]bool{
+	".clj":  true,
+	".cljs": true,
+	".cljc": true,
+}
+
+// isClojureExt returns true for any extension this plugin generates rules
+// for, including .js (rolled up into java_library next to clojure_library).
+func isClojureExt(ext string) bool {
+	if clojureSourceExts[ext] {
+		return true
+	}
+	return ext == ".js"
+}
+
+// sourceRoot finds the source path from initResp.SourcePaths that is a prefix
+// of rel. Returns empty string if none match.
+func sourceRoot(sourcePaths []string, rel string) string {
+	for _, sp := range sourcePaths {
+		if sp == rel || strings.HasPrefix(rel, sp+"/") {
+			return sp
+		}
+	}
+	return ""
+}
+
+// subdirHasClojureFiles checks if a directory recursively contains any
+// .clj/.cljs/.cljc files. Matches gen_srcs behavior which only includes
+// subdirs in __clj_lib rollup if they contain Clojure sources.
+//
+// A WalkDir error (permission denied, broken symlink, etc.) is fatal so a
+// misconfigured tree doesn't silently look "empty" and let Gazelle delete
+// rules for a directory that genuinely contains Clojure files.
+func subdirHasClojureFiles(absDir string) bool {
+	found := false
+	walkErr := filepath.WalkDir(absDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("subdir walk %s: %w", path, err)
+		}
+		if found {
+			return filepath.SkipAll
+		}
+		if !d.IsDir() && clojureSourceExts[filepath.Ext(path)] {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil {
+		log.Fatalf("clojure: %v\n"+
+			"hint: an unreadable subtree would otherwise be reported as 'empty', "+
+			"causing Gazelle to delete rules for directories that have content.", walkErr)
+	}
+	return found
+}
+
+// buildRule translates a Clojure-side {kind, attrs} spec into a Gazelle
+// *rule.Rule. The Clojure server (gen-build/ns-rules) is authoritative on
+// what rules to emit and which attrs to set; this is purely a wire-format
+// translator. Returns an error rather than panicking on malformed specs so
+// the caller can fail the whole run loudly (vs. silently skipping rules).
+func buildRule(spec clojureparser.RuleSpec) (*rule.Rule, error) {
+	if !validRuleKinds[spec.Kind] {
+		return nil, fmt.Errorf("unknown rule kind %q (expected one of clojure_library/clojure_test/clojure_binary/java_library/filegroup)", spec.Kind)
+	}
+	nameRaw, ok := spec.Attrs["name"]
+	if !ok {
+		return nil, fmt.Errorf("rule of kind %q missing :name attr", spec.Kind)
+	}
+	name, ok := nameRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("rule of kind %q has non-string :name (%T)", spec.Kind, nameRaw)
+	}
+	r := rule.NewRule(spec.Kind, name)
+
+	// Apply attrs in sorted order so the generated rule's textual form is
+	// stable across runs.
+	keys := make([]string, 0, len(spec.Attrs))
+	for k := range spec.Attrs {
+		if k != "name" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if err := applyAttr(r, key, spec.Attrs[key]); err != nil {
+			return nil, fmt.Errorf("rule %q attr %q: %w", name, key, err)
+		}
+	}
+	return r, nil
+}
+
+// applyAttr maps one JSON-decoded attr value to rule.SetAttr. JSON numbers
+// always decode to float64, so we coerce integer-valued Bazel attrs back
+// here. Returns an error on unknown shapes so misencodings fail loudly.
+func applyAttr(r *rule.Rule, key string, v interface{}) error {
+	switch val := v.(type) {
+	case nil:
+		return fmt.Errorf("nil value (Clojure must not emit nil attrs — coerce to absent or empty)")
+	case string:
+		r.SetAttr(key, val)
+	case bool:
+		r.SetAttr(key, val)
+	case float64:
+		r.SetAttr(key, int(val))
+	case []interface{}:
+		strs := make([]string, 0, len(val))
+		for i, item := range val {
+			s, ok := item.(string)
+			if !ok {
+				return fmt.Errorf("element %d is %T, expected string", i, item)
+			}
+			strs = append(strs, s)
+		}
+		r.SetAttr(key, strs)
+	case map[string]interface{}:
+		// String-keyed string-valued maps map to Bazel's string_dict attr type
+		// (e.g. clojure_test :env). All-string is the only shape gen-build
+		// emits — fail loudly on anything else so a future Clojure-side change
+		// to a dict with non-string values surfaces here.
+		strDict := make(map[string]string, len(val))
+		for k, v := range val {
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("dict-valued attr: value at key %q is %T, expected string", k, v)
+			}
+			strDict[k] = s
+		}
+		r.SetAttr(key, strDict)
+	default:
+		return fmt.Errorf("unsupported attr type %T", v)
+	}
+	return nil
+}
+
+func (l *clojureLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	// Get config, check extension enabled. A non-Configs value here means
+	// another plugin claimed our languageName slot — fail loudly rather than
+	// silently overwriting it later in Configure.
+	switch raw := args.Config.Exts[languageName].(type) {
+	case nil:
+		return language.GenerateResult{}
+	case clojureconfig.Configs:
+		if !raw.ExtensionEnabled(args.Rel) {
+			return language.GenerateResult{}
+		}
+	default:
+		log.Fatalf("clojure: args.Config.Exts[%q] is %T; expected clojureconfig.Configs (plugin conflict?)", languageName, raw)
+	}
+
+	// Parser session must be running. startParser log.Fatalfs on failure, so
+	// reaching here with a nil session means the extension is enabled but
+	// startParser was never called — fail loudly rather than silently
+	// producing empty results.
+	session := l.session
+	if session == nil {
+		log.Fatalf("clojure: parser not started for %s — "+
+			"check that Configure ran for the root package", args.Rel)
+	}
+
+	// Only process directories under source paths; skip ignored paths.
+	for _, ip := range session.initResp.IgnorePaths {
+		if args.Rel == ip || strings.HasPrefix(args.Rel, ip+"/") {
+			return language.GenerateResult{}
+		}
+	}
+	if sourceRoot(session.initResp.SourcePaths, args.Rel) == "" {
+		return language.GenerateResult{}
+	}
+
+	// Filter files for relevant extensions.
+	files := make([]string, 0, len(args.RegularFiles))
+	for _, f := range args.RegularFiles {
+		if isClojureExt(filepath.Ext(f)) {
+			files = append(files, f)
+		}
+	}
+
+	// Compute the subdir paths whose rollups this package should aggregate.
+	// Gazelle visits children before parents so `hasClojureContent[subRel]`
+	// is populated by the time we ask. Falls back to the on-disk walk for
+	// any subdir we haven't visited yet (defensive — should not happen in
+	// normal Gazelle ordering).
+	var clojureSubdirPaths []string
+	for _, sub := range args.Subdirs {
+		subRel := filepath.Join(args.Rel, sub)
+		if sourceRoot(session.initResp.SourcePaths, subRel) == "" {
+			continue
+		}
+		has, cached := l.hasClojureContent[subRel]
+		if !cached {
+			has = subdirHasClojureFiles(filepath.Join(args.Config.RepoRoot, subRel))
+		}
+		if has {
+			clojureSubdirPaths = append(clojureSubdirPaths, subRel)
+		}
+	}
+	sort.Strings(clojureSubdirPaths)
+
+	// Nothing to do when this package has no direct Clojure/JS files AND no
+	// Clojure-bearing subdirs. Returning early before the parse RPC saves a
+	// round-trip; the rollup would be empty for this package anyway.
+	if len(files) == 0 && len(clojureSubdirPaths) == 0 {
+		return language.GenerateResult{}
+	}
+
+	// Parse the directory. A subprocess transport failure must halt the run:
+	// returning empty GenerateResult{} for previously-rule-bearing packages
+	// would silently delete every clojure_library/clojure_test rule.
+	resp, err := session.runner.Parse(clojureparser.ParseRequest{
+		Dir:                args.Rel,
+		Files:              files,
+		ClojureSubdirPaths: clojureSubdirPaths,
+	})
+	if err != nil {
+		log.Fatalf("clojure: parse %s: %v\n"+
+			"hint: parser subprocess likely died — see stderr above.", args.Rel, err)
+	}
+
+	var gen []*rule.Rule
+	var imports []interface{}
+	hasClojureLibrary := false
+
+	for i := range resp.Namespaces {
+		ns := &resp.Namespaces[i]
+		if ns.Error != "" {
+			log.Fatalf("clojure: parse failed for %s/%s: %s\n"+
+				"hint: see parser subprocess stderr above for the stack trace.",
+				args.Rel, ns.File, ns.Error)
+		}
+		for _, spec := range ns.Rules {
+			r, err := buildRule(spec)
+			if err != nil {
+				log.Fatalf("clojure: %s/%s: %v", args.Rel, ns.File, err)
+			}
+			// Resolve uses NamespaceInfo to look up requires/import_deps/etc.
+			// Only clojure_library rules participate in dep resolution.
+			var imp interface{}
+			if spec.Kind == "clojure_library" {
+				imp = ns
+				hasClojureLibrary = true
+				l.ruleNs[args.Rel+":"+r.Name()] = ns.Ns
+			}
+			gen = append(gen, r)
+			imports = append(imports, imp)
+		}
+	}
+
+	// Translate the rollup specs the Clojure server produced. They already
+	// incorporate `clojureSubdirPaths` from the request, so no further
+	// bookkeeping is needed on the Go side.
+	for _, spec := range resp.RollupRules {
+		r, err := buildRule(spec)
+		if err != nil {
+			log.Fatalf("clojure: %s rollup: %v", args.Rel, err)
+		}
+		gen = append(gen, r)
+		imports = append(imports, nil)
+	}
+
+	// Record whether this package contributes Clojure content for the
+	// parent's rollup. JS-only groups don't count (matches
+	// subdirHasClojureFiles' .clj/.cljs/.cljc-only on-disk check).
+	l.hasClojureContent[args.Rel] = hasClojureLibrary || len(clojureSubdirPaths) > 0
+
+	return language.GenerateResult{
+		Gen:     gen,
+		Empty:   nil,
+		Imports: imports,
+	}
+}
+
+func (*clojureLang) Fix(_ *config.Config, _ *rule.File) {}

--- a/gazelle/generate_test.go
+++ b/gazelle/generate_test.go
@@ -1,0 +1,240 @@
+package gazelle
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	build "github.com/bazelbuild/buildtools/build"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureparser"
+)
+
+func TestIsClojureExt(t *testing.T) {
+	cases := map[string]bool{
+		".clj":  true,
+		".cljs": true,
+		".cljc": true,
+		".js":   true,
+		".java": false,
+		".txt":  false,
+		"":      false,
+	}
+	for ext, want := range cases {
+		if got := isClojureExt(ext); got != want {
+			t.Errorf("isClojureExt(%q) = %v; want %v", ext, got, want)
+		}
+	}
+}
+
+func TestSourceRootMatchesPrefix(t *testing.T) {
+	sourcePaths := []string{"src/main/clojure", "src/test/clojure"}
+	cases := map[string]string{
+		"src/main/clojure":         "src/main/clojure",
+		"src/main/clojure/foo/bar": "src/main/clojure",
+		"src/test/clojure/x":       "src/test/clojure",
+		"src/main":                 "", // shorter than any prefix
+		"unrelated":                "",
+		"":                         "",
+	}
+	for rel, want := range cases {
+		if got := sourceRoot(sourcePaths, rel); got != want {
+			t.Errorf("sourceRoot(%q) = %q; want %q", rel, got, want)
+		}
+	}
+}
+
+func TestSubdirHasClojureFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Empty dir → false.
+	if subdirHasClojureFiles(dir) {
+		t.Errorf("subdirHasClojureFiles(empty) = true; want false")
+	}
+
+	// Non-Clojure file → false.
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if subdirHasClojureFiles(dir) {
+		t.Errorf("subdirHasClojureFiles(only README) = true; want false")
+	}
+
+	// Nested .clj → true.
+	subdir := filepath.Join(dir, "src", "foo")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "core.clj"), []byte("(ns foo.core)"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !subdirHasClojureFiles(dir) {
+		t.Errorf("subdirHasClojureFiles(with nested .clj) = false; want true")
+	}
+
+	// .js does NOT count (rollup excludes JS-only subdirs).
+	jsOnly := t.TempDir()
+	if err := os.WriteFile(filepath.Join(jsOnly, "lib.js"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if subdirHasClojureFiles(jsOnly) {
+		t.Errorf("subdirHasClojureFiles(JS only) = true; want false")
+	}
+}
+
+func TestReadRootModuleName(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"double-quoted", `module(name = "foo")`, "foo"},
+		{"no-spaces", `module(name="bar")`, "bar"},
+		{"single-quoted", `module(name = 'baz')`, "baz"},
+		{"underscored", `module(name = "with_underscore_123")`, "with_underscore_123"},
+		{"with-version-after", `module(name = "foo", version = "1.0")`, "foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if got := readRootModuleName(dir); got != tc.want {
+				t.Errorf("readRootModuleName(%q) = %q; want %q", tc.content, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing MODULE.bazel", func(t *testing.T) {
+		got := readRootModuleName(t.TempDir())
+		if got != "" {
+			t.Errorf("readRootModuleName(no MODULE.bazel) = %q; want \"\"", got)
+		}
+	})
+
+	t.Run("no module() call", func(t *testing.T) {
+		dir := t.TempDir()
+		_ = os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte("# no module"), 0644)
+		got := readRootModuleName(dir)
+		if got != "" {
+			t.Errorf("readRootModuleName(no module call) = %q; want \"\"", got)
+		}
+	})
+}
+
+func TestBuildRuleCoercesAttrTypes(t *testing.T) {
+	spec := clojureparser.RuleSpec{
+		Kind: "clojure_library",
+		Attrs: map[string]interface{}{
+			"name":      "core",
+			"resources": []interface{}{"core.clj", "core.cljs"},
+			"aot":       []interface{}{"my.core"},
+			// Numeric / boolean / string attrs all flow through.
+			"shard_count": float64(4),
+			"flaky":       true,
+			"timeout":     "long",
+		},
+	}
+	r, err := buildRule(spec)
+	if err != nil {
+		t.Fatalf("buildRule: %v", err)
+	}
+	if r.Kind() != "clojure_library" {
+		t.Errorf("kind = %q; want clojure_library", r.Kind())
+	}
+	if r.Name() != "core" {
+		t.Errorf("name = %q; want core", r.Name())
+	}
+	if got := r.AttrStrings("resources"); !reflect.DeepEqual(got, []string{"core.clj", "core.cljs"}) {
+		t.Errorf("resources = %v; want [core.clj core.cljs]", got)
+	}
+	if got := r.AttrStrings("aot"); !reflect.DeepEqual(got, []string{"my.core"}) {
+		t.Errorf("aot = %v; want [my.core]", got)
+	}
+	if got := r.AttrString("timeout"); got != "long" {
+		t.Errorf("timeout = %q; want long", got)
+	}
+	// Numeric + bool attrs aren't readable via AttrStrings/AttrString; just
+	// check they were set at all.
+	for _, k := range []string{"shard_count", "flaky"} {
+		if r.Attr(k) == nil {
+			t.Errorf("attr %q not set", k)
+		}
+	}
+}
+
+func TestBuildRuleRejectsMissingName(t *testing.T) {
+	_, err := buildRule(clojureparser.RuleSpec{
+		Kind:  "clojure_library",
+		Attrs: map[string]interface{}{"resources": []interface{}{"x.clj"}},
+	})
+	if err == nil {
+		t.Error("buildRule with no :name accepted; want error")
+	}
+}
+
+func TestBuildRuleAcceptsStringDictAttr(t *testing.T) {
+	// clojure_test :env is a string_dict; gen-build emits it as a Clojure
+	// map of {string string}. applyAttr must convert to map[string]string
+	// so rule.SetAttr sees the typed shape Bazel emits as a dict literal.
+	r, err := buildRule(clojureparser.RuleSpec{
+		Kind: "clojure_test",
+		Attrs: map[string]interface{}{
+			"name":    "foo",
+			"test_ns": "foo",
+			"env":     map[string]interface{}{"K1": "v1", "K2": "v2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRule with string_dict attr rejected: %v", err)
+	}
+	// rule.Rule has no typed string-dict reader; check that the attr was set
+	// and serializes as a Starlark dict literal containing both keys.
+	expr := r.Attr("env")
+	if expr == nil {
+		t.Fatal("env attr not set")
+	}
+	src := build.FormatString(expr)
+	for _, want := range []string{`"K1": "v1"`, `"K2": "v2"`} {
+		if !strings.Contains(src, want) {
+			t.Errorf("env attr source = %q; want %s", src, want)
+		}
+	}
+}
+
+func TestBuildRuleRejectsNonStringDictValue(t *testing.T) {
+	_, err := buildRule(clojureparser.RuleSpec{
+		Kind: "clojure_test",
+		Attrs: map[string]interface{}{
+			"name":    "foo",
+			"test_ns": "foo",
+			"env":     map[string]interface{}{"K1": 42},
+		},
+	})
+	if err == nil {
+		t.Error("buildRule with non-string dict value accepted; want error")
+	}
+}
+
+func TestBuildRuleRejectsUnknownKind(t *testing.T) {
+	_, err := buildRule(clojureparser.RuleSpec{
+		Kind:  "clojure_libary", // typo
+		Attrs: map[string]interface{}{"name": "x"},
+	})
+	if err == nil {
+		t.Error("buildRule with unknown kind accepted; want error")
+	}
+}
+
+func TestBuildRuleRejectsNilAttr(t *testing.T) {
+	_, err := buildRule(clojureparser.RuleSpec{
+		Kind:  "clojure_library",
+		Attrs: map[string]interface{}{"name": "x", "resources": nil},
+	})
+	if err == nil {
+		t.Error("buildRule with nil attr accepted; want error")
+	}
+}

--- a/gazelle/go.mod
+++ b/gazelle/go.mod
@@ -1,0 +1,12 @@
+module github.com/griffinbank/rules_clojure/gazelle
+
+go 1.25.0
+
+require github.com/bazelbuild/bazel-gazelle v0.47.0
+
+require (
+	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 // indirect
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
+)

--- a/gazelle/go.sum
+++ b/gazelle/go.sum
@@ -1,0 +1,14 @@
+github.com/bazelbuild/bazel-gazelle v0.47.0 h1:g3Rr1ZbkC1Pk20aOgBITxSD/efS1WbaSty5jC786Z3Q=
+github.com/bazelbuild/bazel-gazelle v0.47.0/go.mod h1:8Ozf20jhv+in87nCUHdmUPPcVGTfKg/gotZ/hce3T+w=
+github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=
+github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
+github.com/bazelbuild/rules_go v0.53.0 h1:u160DT+RRb+Xb2aSO4piN8xhs4aZvWz2UDXCq48F4ao=
+github.com/bazelbuild/rules_go v0.53.0/go.mod h1:xB1jfsYHWlnZyPPxzlOSst4q2ZAwS251Mp9Iw6TPuBc=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools/go/vcs v0.1.0-deprecated h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=
+golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHIV4Z7g63sNPVMtuBy8=

--- a/gazelle/lang.go
+++ b/gazelle/lang.go
@@ -1,0 +1,140 @@
+// Package gazelle is the Clojure language plugin for Gazelle. It is glue
+// between Gazelle's language.Language interface and a long-running Clojure
+// parser subprocess (gazelle/clojureparser). The parser owns rule
+// construction via rules-clojure.gen-build; this package translates the
+// resulting {kind, attrs} specs into *rule.Rule and runs cross-package
+// dep resolution against Gazelle's index.
+package gazelle
+
+import (
+	"context"
+	"log"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureparser"
+)
+
+const languageName = "clojure"
+
+// parserSession bundles the three fields that share a lifetime: they're set
+// together in startParser and cleared together in AfterResolvingDeps.
+// Grouping them lets callers check `l.session == nil` instead of any one
+// field individually, avoiding a fragile "parser != nil implies initResp
+// != nil" invariant.
+type parserSession struct {
+	runner      *clojureparser.Runner
+	initResp    *clojureparser.InitResponse
+	depsRepoTag string
+}
+
+type clojureLang struct {
+	session *parserSession
+	// ruleNs maps "pkg:ruleName" to namespace name for cross-reference
+	// indexing. Populated during GenerateRules, read during Imports.
+	ruleNs map[string]string
+	// hasClojureContent records whether `rel` has any Clojure rules or
+	// transitively contains a subdir that does. Populated bottom-up by
+	// GenerateRules so the parent's `__clj_lib` rollup check is an O(1)
+	// map lookup instead of an O(n) WalkDir per subdir.
+	hasClojureContent map[string]bool
+}
+
+// Compile-time interface checks.
+var _ language.Language = (*clojureLang)(nil)
+var _ language.ModuleAwareLanguage = (*clojureLang)(nil)
+var _ language.LifecycleManager = (*clojureLang)(nil)
+
+func NewLanguage() language.Language {
+	return &clojureLang{
+		ruleNs:            make(map[string]string),
+		hasClojureContent: make(map[string]bool),
+	}
+}
+
+func (*clojureLang) Name() string {
+	return languageName
+}
+
+func (*clojureLang) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		"clojure_library": {
+			NonEmptyAttrs:  map[string]bool{"resources": true},
+			MergeableAttrs: map[string]bool{"resources": true, "srcs": true},
+			ResolveAttrs:   map[string]bool{"deps": true},
+		},
+		"clojure_test": {
+			NonEmptyAttrs: map[string]bool{"test_ns": true},
+			// No ResolveAttrs — Resolve below short-circuits unless
+			// Kind() == "clojure_library", so declaring "deps" as a
+			// resolve-attr would let Gazelle clear it without ever giving
+			// us a chance to rebuild it.
+		},
+		"clojure_binary": {
+			NonEmptyAttrs: map[string]bool{"main_class": true},
+			// No ResolveAttrs — binaries get their dep on the library
+			// directly from gen-build/ns-rules' :runtime_deps.
+		},
+		"java_library": {
+			NonEmptyAttrs:  map[string]bool{"resources": true},
+			MergeableAttrs: map[string]bool{"resources": true},
+		},
+		"filegroup": {
+			NonEmptyAttrs:  map[string]bool{"srcs": true},
+			MergeableAttrs: map[string]bool{"srcs": true},
+		},
+	}
+}
+
+// Loads implements the deprecated Language.Loads. We use ApparentLoads
+// instead but some Gazelle code paths still consult Loads; delegate so the
+// two views agree. `clojure_library`, `clojure_test`, and `clojure_binary`
+// need an explicit load — `java_library` and `filegroup` are Bazel built-ins.
+func (l *clojureLang) Loads() []rule.LoadInfo {
+	return l.ApparentLoads(func(s string) string { return s })
+}
+
+// ApparentLoads implements ModuleAwareLanguage. The
+// `moduleToApparentName` callback maps a canonical module name to whatever
+// apparent name the user gave it in MODULE.bazel; we use it so a user who
+// imports rules_clojure as `@my_rules_clojure` still gets a working load().
+// log.Fatalf when rules_clojure isn't a bzlmod dep — falling back to the
+// canonical name produces a Bazel-load error far from the cause.
+func (*clojureLang) ApparentLoads(moduleToApparentName func(string) string) []rule.LoadInfo {
+	apparent := moduleToApparentName("rules_clojure")
+	if apparent == "" {
+		log.Fatalf("clojure: rules_clojure not declared in MODULE.bazel — " +
+			"add `bazel_dep(name = \"rules_clojure\", version = \"...\")` before running gazelle.")
+	}
+	return []rule.LoadInfo{
+		{
+			Name:    "@" + apparent + "//:rules.bzl",
+			Symbols: []string{"clojure_library", "clojure_test", "clojure_binary"},
+		},
+	}
+}
+
+// LifecycleManager methods.
+
+func (*clojureLang) Before(ctx context.Context) {}
+
+func (lang *clojureLang) DoneGeneratingRules() {
+	// ruleNs is populated during GenerateRules and read by Imports() for
+	// newly generated rules; rules already in existing BUILD files take the
+	// AOT-attr fallback in resolve.go. Release the map but keep a usable
+	// empty value so an unexpected post-Done GenerateRules call doesn't
+	// panic on a nil map.
+	lang.ruleNs = make(map[string]string)
+}
+
+func (lang *clojureLang) AfterResolvingDeps(ctx context.Context) {
+	if lang.session == nil {
+		// Startup failed earlier; log.Fatalf already aborted. Reaching here
+		// in tests or library use without startParser is a no-op.
+		return
+	}
+	lang.session.runner.Shutdown()
+	lang.session = nil
+	log.Println("clojure: parser shut down")
+}

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -1,0 +1,167 @@
+// resolve.go implements Gazelle's Resolver interface (Imports, Embeds,
+// Resolve). Gazelle calls Imports(rule) per generated rule to index what
+// each rule "provides" (here: the rule's namespace symbol so other
+// packages' requires can find it). After indexing, Gazelle calls
+// Resolve(rule) to fill in :deps.
+//
+// Static deps that don't need Gazelle's cross-package index
+// (org_clojure_clojure, ns-library-meta extras, pre-resolved
+// import-deps / gen-class-deps) are pre-merged Clojure-side via
+// gen-build/ns-rules and seeded into the depSet from the rule's
+// existing :deps. This file adds only:
+//   - Intra-repo lookups via FindRulesByImport (a require like `foo.bar`
+//     resolves to `//src/foo:bar` when another package generated it).
+//   - Per-target deps_bazel overrides, which are keyed on the rule's
+//     final Bazel label — unknowable to ns-rules, so Go must do it here.
+//
+// Note on `clojure_deps_repo` directive scope: per-package overrides only
+// retag externally-resolved labels added by this file. Seed deps in the
+// rule's existing :deps were emitted Clojure-side at init time using the
+// root tag, so a sub-package override produces a mixed list. Mixing is
+// intentional — the seed deps reference Maven coords resolved against the
+// root deps.edn and don't move when a sub-package overrides for its own
+// custom deps.bzl. If you need a sub-package to use a completely different
+// dep universe, run a second Gazelle invocation with a different root.
+package gazelle
+
+import (
+	"sort"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureconfig"
+	"github.com/griffinbank/rules_clojure/gazelle/clojureparser"
+)
+
+func (l *clojureLang) Imports(_ *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	if r.Kind() != "clojure_library" {
+		return nil
+	}
+	// Look up namespace from our generation-time mapping.
+	key := f.Pkg + ":" + r.Name()
+	if ns, ok := l.ruleNs[key]; ok {
+		return []resolve.ImportSpec{
+			{Lang: languageName, Imp: ns},
+		}
+	}
+	// Fallback: rules already in existing BUILD files (not freshly generated
+	// this run) — index every AOT'd namespace so cross-package :requires can
+	// resolve to any of them. Rules with no AOT attr stay un-indexed: there
+	// is no other source of truth for which namespaces a pre-existing rule
+	// provides.
+	aot := r.AttrStrings("aot")
+	if len(aot) == 0 {
+		return nil
+	}
+	specs := make([]resolve.ImportSpec, 0, len(aot))
+	for _, ns := range aot {
+		specs = append(specs, resolve.ImportSpec{Lang: languageName, Imp: ns})
+	}
+	return specs
+}
+
+func (*clojureLang) Embeds(_ *rule.Rule, _ label.Label) []label.Label {
+	return nil
+}
+
+func (l *clojureLang) Resolve(c *config.Config, ix *resolve.RuleIndex, _ *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+	if r.Kind() != "clojure_library" {
+		return
+	}
+	ns, ok := imports.(*clojureparser.NamespaceInfo)
+	if !ok || ns == nil {
+		return
+	}
+
+	session := l.session
+	if session == nil {
+		// Resolve runs after GenerateRules, which would have log.Fatalf'd if
+		// the parser never started. Defensive guard for callers that skip
+		// the normal lifecycle (tests, etc.).
+		return
+	}
+
+	// Honour per-package `# gazelle:clojure_deps_repo @other_deps` for
+	// external dep labels. DepsRepo walks the parent chain and falls back
+	// to the default tag, so it always returns a non-empty value.
+	depsRepoTag := session.depsRepoTag
+	if configs, ok := c.Exts[languageName].(clojureconfig.Configs); ok {
+		depsRepoTag = configs.DepsRepo(from.Pkg)
+	}
+
+	// Seed depSet with the deps gen-build/ns-rules already merged
+	// (org_clojure_clojure + clojure-library-args + ns-library-meta +
+	// import-deps + gen-class-deps). Resolve adds only what needs Gazelle's
+	// cross-package index: intra-repo lookup, per-platform external
+	// resolution, and per-target deps_bazel overrides.
+	depSet := make(map[string]struct{})
+	for _, dep := range r.AttrStrings("deps") {
+		depSet[dep] = struct{}{}
+	}
+
+	// Per-require resolution: try intra-repo index first (platform-
+	// independent), fall back to external DepNsLabels for this platform.
+	// gen_srcs cross-products files × platforms, producing redundant deps
+	// (both AOT and plain library for the same dep). We intentionally
+	// don't replicate this — the AOT target already depends on the plain
+	// library, so the extra dep is unnecessary.
+	for _, platform := range ns.Platforms {
+		reqNs, ok := ns.Requires[platform]
+		if !ok {
+			continue
+		}
+		for _, reqName := range reqNs {
+			spec := resolve.ImportSpec{Lang: languageName, Imp: reqName}
+			if matches := ix.FindRulesByImport(spec, languageName); len(matches) > 0 {
+				lbl := matches[0].Label
+				depSet[label.New("", lbl.Pkg, lbl.Name).String()] = struct{}{}
+				continue
+			}
+			if platformMap, ok := session.initResp.DepNsLabels[platform]; ok {
+				if lbl, ok := platformMap[reqName]; ok {
+					depSet[depsRepoTag+"//:"+lbl] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// Per-target deps_bazel override (can't be pre-merged on the Clojure
+	// side — ns-rules doesn't know the eventual Bazel label).
+	mergeDepsBazelTargetDeps(depSet, session.initResp.DepsBazel, from)
+
+	// Exclude self-deps (e.g. .cljc files with :require-macros of themselves
+	// resolve to the same target). Self-label is rebuilt with an empty repo
+	// segment to match the form `depSet` entries use for intra-repo deps.
+	selfLabel := label.New("", from.Pkg, from.Name).String()
+	delete(depSet, selfLabel)
+
+	deps := make([]string, 0, len(depSet))
+	for dep := range depSet {
+		deps = append(deps, dep)
+	}
+	sort.Strings(deps)
+	r.SetAttr("deps", deps)
+}
+
+// mergeDepsBazelTargetDeps adds per-target extra deps from
+// deps_bazel.Deps[label].Deps. Per-target overrides are keyed on the rule's
+// final Bazel label, which ns-rules doesn't know — so this stays Go-side
+// where Gazelle hands us the `from` label during Resolve.
+//
+// Typed via the DepsBazel struct: malformed shapes (wrong nesting, wrong
+// element types) fail at clojureparser.Init's json.Unmarshal with a clear
+// error, before reaching this function. By the time this runs, the wire
+// shape is known good.
+func mergeDepsBazelTargetDeps(depSet map[string]struct{}, depsBazel clojureparser.DepsBazel, from label.Label) {
+	target, ok := depsBazel.Deps[from.String()]
+	if !ok {
+		return
+	}
+	for _, dep := range target.Deps {
+		depSet[dep] = struct{}{}
+	}
+}

--- a/gazelle/resolve_test.go
+++ b/gazelle/resolve_test.go
@@ -1,0 +1,96 @@
+package gazelle
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+
+	"github.com/griffinbank/rules_clojure/gazelle/clojureparser"
+)
+
+func TestImportsNonClojureLibrary(t *testing.T) {
+	l := &clojureLang{ruleNs: map[string]string{}}
+	r := rule.NewRule("clojure_test", "core.test")
+	got := l.Imports(nil, r, &rule.File{Pkg: "src/foo"})
+	if got != nil {
+		t.Errorf("Imports for clojure_test = %v; want nil", got)
+	}
+}
+
+func TestImportsRuleNsHit(t *testing.T) {
+	l := &clojureLang{ruleNs: map[string]string{"src/foo:core": "foo.core"}}
+	r := rule.NewRule("clojure_library", "core")
+	got := l.Imports(nil, r, &rule.File{Pkg: "src/foo"})
+	if len(got) != 1 || got[0].Imp != "foo.core" {
+		t.Errorf("Imports = %v; want one spec with Imp=foo.core", got)
+	}
+}
+
+func TestImportsAOTFallbackMultipleNs(t *testing.T) {
+	l := &clojureLang{ruleNs: map[string]string{}}
+	r := rule.NewRule("clojure_library", "lib")
+	r.SetAttr("aot", []string{"foo.a", "foo.b", "foo.c"})
+	got := l.Imports(nil, r, &rule.File{Pkg: "src/foo"})
+	if len(got) != 3 {
+		t.Fatalf("Imports = %v; want 3 specs (one per AOT ns)", got)
+	}
+	want := []string{"foo.a", "foo.b", "foo.c"}
+	imps := []string{got[0].Imp, got[1].Imp, got[2].Imp}
+	sort.Strings(imps)
+	if !reflect.DeepEqual(imps, want) {
+		t.Errorf("Imports AOT imps = %v; want %v", imps, want)
+	}
+}
+
+func TestImportsAOTAbsentReturnsNil(t *testing.T) {
+	l := &clojureLang{ruleNs: map[string]string{}}
+	r := rule.NewRule("clojure_library", "lib")
+	got := l.Imports(nil, r, &rule.File{Pkg: "src/foo"})
+	if got != nil {
+		t.Errorf("Imports with no ruleNs / no aot = %v; want nil", got)
+	}
+}
+
+func TestMergeDepsBazelTargetDepsAbsent(t *testing.T) {
+	depSet := map[string]struct{}{}
+	mergeDepsBazelTargetDeps(depSet, clojureparser.DepsBazel{}, label.New("", "src/foo", "core"))
+	if len(depSet) != 0 {
+		t.Errorf("depSet = %v; want empty (no deps_bazel.Deps entries)", depSet)
+	}
+}
+
+func TestMergeDepsBazelTargetDepsHappyPath(t *testing.T) {
+	depSet := map[string]struct{}{"@deps//:existing": {}}
+	from := label.New("", "src/foo", "core")
+	depsBazel := clojureparser.DepsBazel{
+		Deps: map[string]clojureparser.DepsBazelTarget{
+			from.String(): {Deps: []string{"@deps//:extra1", "@deps//:extra2"}},
+		},
+	}
+	mergeDepsBazelTargetDeps(depSet, depsBazel, from)
+	keys := make([]string, 0, len(depSet))
+	for k := range depSet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	want := []string{"@deps//:existing", "@deps//:extra1", "@deps//:extra2"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("depSet keys = %v; want %v", keys, want)
+	}
+}
+
+func TestMergeDepsBazelTargetDepsUnmatchedLabel(t *testing.T) {
+	depSet := map[string]struct{}{}
+	depsBazel := clojureparser.DepsBazel{
+		Deps: map[string]clojureparser.DepsBazelTarget{
+			"//src/bar:other": {Deps: []string{"@deps//:nope"}},
+		},
+	}
+	mergeDepsBazelTargetDeps(depSet, depsBazel, label.New("", "src/foo", "core"))
+	if len(depSet) != 0 {
+		t.Errorf("depSet = %v; want empty (label didn't match)", depSet)
+	}
+}

--- a/src/rules_clojure/BUILD
+++ b/src/rules_clojure/BUILD
@@ -13,6 +13,8 @@ java_library(
                "bootstrap_libfs.clj",
                "bootstrap_worker.clj",
                "bootstrap_testrunner.clj",
+               "bootstrap_gazelle_server.clj",
+               "gazelle_server.clj",
                "compile.clj",
                "fs.clj",
                "jar.clj",
@@ -131,6 +133,26 @@ java_binary(name="gen_build",
             main_class="rules_clojure.gen_build",
             runtime_deps=[":libgen_build"],
             jvm_flags = ["-Xmx500m", "-XX:MaxMetaspaceSize=500m"])
+
+genrule(
+    name="bootstrap-gazelle-server",
+    tools=[":bootstrap-bin"],
+    cmd="""
+    mkdir -p gazelle-server-classes
+    $(location :bootstrap-bin) -m rules-clojure.bootstrap-gazelle-server $(location :libgazelle_server.jar)
+    """,
+    outs=["libgazelle_server.jar"])
+
+java_import(name="libgazelle_server",
+            jars=["libgazelle_server.jar"],
+            runtime_deps=[":libgen_build"],
+            data=[":bootstrap-gazelle-server"])
+
+java_binary(name="gazelle_server",
+            main_class="rules_clojure.gazelle_server",
+            runtime_deps=[":libgazelle_server"],
+            jvm_flags=["-Xmx500m", "-XX:MaxMetaspaceSize=500m"],
+            visibility=["//visibility:public"])
 
 java_library(name="srcjar",
              resources=glob(["*.clj"]),

--- a/src/rules_clojure/bootstrap_gazelle_server.clj
+++ b/src/rules_clojure/bootstrap_gazelle_server.clj
@@ -1,0 +1,29 @@
+(ns rules-clojure.bootstrap-gazelle-server
+  (:require [rules-clojure.bootstrap-gen-build :as bgb]
+            [rules-clojure.jar :as jar]
+            [rules-clojure.fs :as fs]))
+
+(def nses-to-compile
+  "gen-build's compile set plus the gazelle-server namespace itself. Reuses
+  bootstrap-gen-build/nses-to-compile rather than duplicating the list, so
+  adding a tools.deps / namespace-reader dependency in one place updates
+  both deploy jars."
+  (conj bgb/nses-to-compile 'rules-clojure.gazelle-server))
+
+(def classes-dir "gazelle-server-classes")
+
+(defn -main [jar-path]
+  (fs/clean-directory (fs/->path classes-dir))
+
+  (binding [*compile-path* classes-dir]
+    (doseq [n nses-to-compile]
+      ;; Wrap each compile so the genrule stack trace names the failing ns
+      ;; instead of just pointing into clojure.core/load.
+      (try
+        (compile n)
+        (catch Throwable t
+          (throw (ex-info (str "compile failed for " n) {:ns n} t))))))
+
+  (jar/create-jar {:aot-nses '[rules-clojure.gazelle-server]
+                   :classes-dir (fs/->path classes-dir)
+                   :output-jar (fs/->path jar-path)}))

--- a/src/rules_clojure/gazelle_server.clj
+++ b/src/rules_clojure/gazelle_server.clj
@@ -1,0 +1,338 @@
+(ns rules-clojure.gazelle-server
+  (:require [clojure.data.json :as json]
+            [clojure.set :as set]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]
+            [rules-clojure.fs :as fs]
+            [rules-clojure.gen-build :as gen-build]
+            [rules-clojure.namespace.parse :as parse])
+  (:import (java.io BufferedReader BufferedWriter InputStreamReader OutputStreamWriter))
+  (:gen-class))
+
+(set! *warn-on-reflection* true)
+
+(defn read-request
+  "Read a JSON line from reader, return parsed map with keyword keys or nil on EOF."
+  [^BufferedReader reader]
+  (when-let [line (.readLine reader)]
+    (json/read-str line :key-fn keyword)))
+
+(defn write-response
+  "Write a map as a single JSON line to writer, then flush."
+  [^BufferedWriter writer resp]
+  (.write writer (json/write-str resp))
+  (.newLine writer)
+  (.flush writer))
+
+(defn- strip-leading-colon
+  "Aliases arriving from the Gazelle directive `clojure_aliases :foo,:bar`
+  carry a leading colon; `(keyword \":foo\")` would produce a malformed
+  keyword whose name is `:foo`. Strip the colon before calling keyword."
+  [a]
+  (cond-> a (str/starts-with? a ":") (subs 1)))
+
+(s/def ::deps_edn_path string?)
+(s/def ::repository_dir string?)
+(s/def ::deps_repo_tag string?)
+(s/def ::root_module_name (s/nilable string?))
+(s/def ::aliases (s/coll-of string? :kind sequential?))
+(s/def ::init-request
+  (s/keys :req-un [::deps_edn_path ::repository_dir ::deps_repo_tag ::aliases]
+          :opt-un [::root_module_name]))
+
+(defn init-state
+  "Process an init request. Returns `{:response wire :state internal}`.
+   Splitting the return shape (rather than smuggling `:state` inside `wire`)
+   makes it impossible for a future caller to forget to dissoc internal
+   state before serialization.
+
+   `clojure.data.json` stringifies keyword and symbol keys automatically,
+   so the response map can carry native keyword/symbol keys directly."
+  [{:keys [deps_edn_path repository_dir deps_repo_tag root_module_name aliases]}]
+  (let [deps-edn-path    (-> deps_edn_path fs/->path fs/absolute)
+        deps-edn-dir     (fs/dirname deps-edn-path)
+        repository-dir   (fs/->path repository_dir)
+        deps-repo-tag    deps_repo_tag
+        root-module-name root_module_name
+        aliases          (mapv (comp keyword strip-leading-colon) aliases)
+        read-deps        (gen-build/read-deps deps-edn-path)
+        deps-bazel       (gen-build/parse-deps-bazel read-deps (or root-module-name ""))
+        basis            (gen-build/make-basis {:read-deps      read-deps
+                                                :aliases        aliases
+                                                :repository-dir repository-dir
+                                                :deps-edn-path  deps-edn-path})
+        dep-ns->label    (gen-build/->dep-ns->label {:basis         basis
+                                                     :deps-bazel    deps-bazel
+                                                     :deps-repo-tag deps-repo-tag})
+        jar->lib         (gen-build/->jar->lib basis)
+        class->jar       (gen-build/->class->jar basis)
+        ignore-paths     (:ignore deps-bazel)]
+    {:response {:type          "init"
+                :dep_ns_labels dep-ns->label
+                :deps_bazel    (dissoc deps-bazel :no-aot :ignore)
+                :ignore_paths  (vec ignore-paths)
+                :source_paths  (mapv str (:paths basis))}
+     :state    {:basis         basis
+                :deps-bazel    deps-bazel
+                :jar->lib      jar->lib
+                :class->jar    class->jar
+                :dep-ns->label dep-ns->label
+                :deps-edn-path deps-edn-path
+                :deps-edn-dir  deps-edn-dir
+                :deps-repo-tag deps-repo-tag
+                :aliases       aliases}}))
+
+(defn- ext->platforms
+  "Map a file extension to the set of platforms it supports."
+  [ext]
+  (case ext
+    "clj"  #{:clj}
+    "cljs" #{:cljs}
+    "cljc" #{:clj :cljs}
+    #{}))
+
+(defn- file-ext
+  "Return the file extension (without dot) or nil."
+  [filename]
+  (let [s (str filename)]
+    (when-let [i (str/last-index-of s ".")]
+      (subs s (inc i)))))
+
+(defn- file-for-platform
+  "Return the first file in `files` whose extension supports `plat`, or nil."
+  [plat files]
+  (first (filter #(contains? (ext->platforms (file-ext %)) plat) files)))
+
+(defn- rule-spec->wire
+  "Translate a {:type :clojure_library :attrs {:name ... :deps [...]}} from
+  ns-rules into wire shape: stringified type, qualified-keyword attr names
+  (so the Go side can range a map[string]interface{}).
+
+  Keep :deps for every kind. ns-rules-args supplies empty src-ns->label /
+  dep-ns->label so ns-rules merges only the static parts (org_clojure_clojure
+  + clojure-library-args + ns-library-meta + import-deps + gen-class-deps).
+  Gazelle's Resolve seeds depSet from these and adds the per-require
+  intra-repo / DepNsLabels resolution + per-target deps_bazel overrides."
+  [{:keys [type attrs]}]
+  {:kind (name type)
+   :attrs (->> attrs (reduce-kv (fn [m k v] (assoc m (name k) v)) {}))})
+
+(defn- ns-rules-args
+  "Build the args map ns-rules expects from the persistent server state.
+  src-ns->label is empty (intra-repo resolution is Gazelle's job — index
+  isn't available here). dep-ns->label is empty so ns-rules' per-require
+  external lookup is a no-op; the Go-side Resolve does that lookup against
+  initResp.DepNsLabels with proper intra-repo-wins semantics."
+  [state]
+  (-> (select-keys state [:basis :deps-edn-dir :deps-bazel :deps-repo-tag
+                          :jar->lib :class->jar])
+      (assoc :src-ns->label {})
+      (assoc :dep-ns->label {:clj {} :cljs {}})))
+
+(defn- exception-chain
+  "Walk a Throwable's getCause chain and join class+message for each link.
+  Preserves root-cause class (EOFException vs FileNotFoundException etc.) that
+  `.getMessage` alone collapses when an outer wrapper rewraps the cause."
+  [^Throwable t]
+  (->> (iterate #(.getCause ^Throwable %) t)
+       (take-while some?)
+       (mapv (fn [^Throwable x]
+               (let [klass (.getName (class x))
+                     msg   (.getMessage x)]
+                 (if msg (str klass ": " msg) klass))))
+       (str/join " -> ")))
+
+(defn parse-namespace-group
+  "Parse a group of files sharing a basename within dir. Returns:
+   - empty vector when no file in the group declares a namespace AND has
+     no JS files (e.g. resource-only files like data_readers.clj)
+   - vector of one map with namespace info + rule specs on success.
+     `:rules` comes from gen-build/ns-rules so the Go side doesn't
+     re-implement AOT decisions, test-attr passthrough, or binary emission.
+     Rules are keyword-shaped here; `handle-parse` wire-converts them at
+     the response boundary. For JS-only groups :js-only? is true and
+     :ns/:requires are absent — the Go side branches on Kind, not on :ns.
+   - vector of one {:error ... :file ...} entry on parse failure
+     (caller MUST treat as fatal — silent drop deletes existing rules).
+
+  An `ns-rules-args` map can be precomputed by the caller and passed in via
+  `:ns-rules-args` of `state` to skip per-group rebuild."
+  [state dir files]
+  (try
+    (let [abs-dir (let [d (fs/->path dir)]
+                    (if (fs/absolute? d) d (fs/->path (:deps-edn-dir state) dir)))
+          abs-paths (mapv #(fs/->path abs-dir %) files)
+          clj-files (filterv #(contains? #{"clj" "cljc" "cljs"} (file-ext %)) files)
+          js-only? (and (empty? clj-files) (seq files))
+          ns-args   (or (:ns-rules-args state) (ns-rules-args state))]
+      (cond
+        ;; All-JS group: java_library rule only. :ns/:requires are absent
+        ;; because Go's Resolve short-circuits on Kind != "clojure_library"
+        ;; (resolve.go:57), so neither field is ever read for JS-only.
+        js-only?
+        [{:file      (str (first files))
+          :platforms ["js"]
+          :rules     (vec (gen-build/ns-rules ns-args abs-paths))}]
+
+        :else
+        (let [platforms (apply set/union (map #(ext->platforms (file-ext %)) clj-files))
+              primary-platform (if (contains? platforms :clj) :clj :cljs)
+              ;; Read the ns-decl once per (file, platform) pair. A primary
+              ;; file may not declare a namespace (resource-only data_readers
+              ;; .clj); a sibling .cljs may still declare one. Build the full
+              ;; map and pick primary if present, else any non-nil decl —
+              ;; only treat the group as resource-only if NO file has ns.
+              decls-by-plat (into {}
+                                  (for [plat (sort-by name platforms)
+                                        :let [f (file-for-platform plat clj-files)
+                                              p (fs/->path abs-dir f)
+                                              decl (gen-build/get-ns-decl p plat)]
+                                        :when decl]
+                                    [plat decl]))
+              primary-file (file-for-platform primary-platform clj-files)
+              ns-decl (or (get decls-by-plat primary-platform)
+                          (some decls-by-plat (sort-by name platforms)))]
+          (if (nil? ns-decl)
+            ;; clj* files exist but none declare a namespace (resource-only,
+            ;; e.g. data_readers.clj). Skip ns-rules — its get-ns-meta /
+            ;; ns-deps callees would read the file as a non-ns form and
+            ;; assert. Resource-only groups need no Bazel rule.
+            []
+            (let [ns-name (str (second ns-decl))
+                  requires (into (sorted-map)
+                                 (for [[plat decl] decls-by-plat
+                                       :let [deps (mapv str (parse/deps-from-ns-decl decl))]
+                                       :when (seq deps)]
+                                   [(name plat) (vec (sort deps))]))
+                  ;; Drop any abs-path whose natural platforms have no decl —
+                  ;; otherwise ns-rules' get-ns-meta would assert on a resource-
+                  ;; only sibling (e.g. data_readers.clj alongside a declaring
+                  ;; data_readers.cljs).
+                  rule-paths (filterv (fn [p]
+                                        (some #(get decls-by-plat %)
+                                              (ext->platforms (str (fs/extension p)))))
+                                      abs-paths)
+                  rules (if (seq rule-paths)
+                          (vec (gen-build/ns-rules ns-args rule-paths))
+                          [])]
+              [{:ns        ns-name
+                :file      (str primary-file)
+                :requires  requires
+                :platforms (vec (sort (map name platforms)))
+                :rules     rules}])))))
+    (catch Throwable t
+      (binding [*out* *err*]
+        (println "gazelle-server: error parsing" dir (mapv str files))
+        (.printStackTrace t ^java.io.PrintWriter *err*))
+      ;; Return a tagged error entry rather than [] so the Go caller can
+      ;; distinguish "no ns form" from "parse failed" and abort instead of
+      ;; silently deleting BUILD rules. Preserve the cause chain so root-
+      ;; cause class (EOFException etc.) isn't collapsed by an outer wrap.
+      [{:error (exception-chain t)
+        :file  (str (first files))}])))
+
+(def ^:private rollup-kinds
+  "Rule types that contribute to the __clj_lib / __clj_files rollup. These
+  are keywords because rules are kept keyword-shaped through aggregation
+  (rule-spec->wire stringifies later at the response boundary)."
+  #{:clojure_library :java_library})
+
+(defn- lib-names-from-rules
+  "Pull the names of rules eligible for __clj_lib rollup from per-namespace
+  rule specs."
+  [namespaces]
+  (into []
+        (comp (mapcat :rules)
+              (filter (comp rollup-kinds :type))
+              (map (comp :name :attrs))
+              (distinct))
+        namespaces))
+
+(defn- src-files-from-rules
+  "Pull file basenames for __clj_files rollup (all resources of the rollup
+  rules — clojure_library + java_library)."
+  [namespaces]
+  (into []
+        (comp (mapcat :rules)
+              (filter (comp rollup-kinds :type))
+              (mapcat (comp :resources :attrs))
+              (distinct))
+        namespaces))
+
+(s/def ::dir string?)
+(s/def ::files (s/coll-of string? :kind sequential?))
+(s/def ::clojure_subdir_paths (s/coll-of string? :kind sequential?))
+(s/def ::parse-request
+  (s/keys :req-un [::dir ::files]
+          :opt-un [::clojure_subdir_paths]))
+
+(defn handle-parse
+  "Process a parse request. Returns:
+     {:type \"parse\"
+      :namespaces [{...per-namespace + :rules} ...]
+      :rollup_rules [...__clj_lib / __clj_files specs...]}
+
+  Mirrors gen-dir: clj+js files are grouped by basename and each group flows
+  through ns-rules so a `webauthn.clj` + `webauthn.js` pair produces ONE
+  clojure_library. Rollup specs aggregate the local rule names plus any
+  subdir labels the caller provides via `clojure_subdir_paths` — Gazelle's
+  Go side knows which children transitively contain Clojure content.
+
+  Rules are kept keyword-shaped through aggregation; `rule-spec->wire` is
+  applied once at the response boundary so the lib/src-files extraction can
+  read `:name`/`:resources` as keywords (not the stringified-attr shape)."
+  [state {:keys [dir files clojure_subdir_paths] :as request}]
+  (when-not (s/valid? ::parse-request request)
+    (throw (ex-info (str "invalid parse request: "
+                         (s/explain-str ::parse-request request))
+                    {:request request})))
+  (let [relevant (filterv (some-fn gen-build/clj*-path? gen-build/js-path?) files)
+        groups (->> relevant
+                    (group-by #(fs/basename (fs/->path %)))
+                    (sort-by key)
+                    (mapv val))
+        ns-args (ns-rules-args state)
+        state' (assoc state :ns-rules-args ns-args)
+        parsed (into [] (mapcat #(parse-namespace-group state' dir %)) groups)
+        rollup-specs (gen-build/rollup-rules
+                      {:lib-deps             (lib-names-from-rules parsed)
+                       :src-files            (src-files-from-rules parsed)
+                       :clojure-subdir-paths (or clojure_subdir_paths [])})]
+    {:type         "parse"
+     :namespaces   (mapv #(update % :rules (partial mapv rule-spec->wire)) parsed)
+     :rollup_rules (mapv rule-spec->wire rollup-specs)}))
+
+(defn handle-request
+  "Dispatch a single request. Returns the wire-response map and mutates the
+  state atom on init. Wrapped in try/catch by `-main` so a single bad request
+  returns an error envelope rather than killing the server."
+  [!state request]
+  (case (:type request)
+    "init"  (let [{:keys [response state]} (init-state request)]
+              (reset! !state state)
+              response)
+    "parse" (if (nil? @!state)
+              {:type "error" :message "parse received before init"}
+              (handle-parse @!state request))
+    {:type "error" :message (str "unknown request type: " (:type request))}))
+
+(defn -main [& _args]
+  (let [reader (BufferedReader. (InputStreamReader. System/in))
+        writer (BufferedWriter. (OutputStreamWriter. System/out))
+        !state (atom nil)]
+    (loop []
+      (let [request (try
+                      (read-request reader)
+                      (catch Throwable t
+                        (binding [*out* *err*]
+                          (println "gazelle-server: read failed:" (.getMessage t)))
+                        ::eof))]
+        (when (and (some? request) (not= ::eof request))
+          (let [response (try
+                           (handle-request !state request)
+                           (catch Throwable t
+                             (binding [*out* *err*]
+                               (.printStackTrace t ^java.io.PrintWriter *err*))
+                             {:type "error" :message (exception-chain t)}))]
+            (write-response writer response)
+            (recur)))))))

--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -611,13 +611,13 @@
 
 (s/fdef clj-path? :args (s/cat :p fs/path?) :ret boolean?)
 (defn clj-path? [path]
-  (boolean (re-find #"\.clj$" (str path))))
+  (str/ends-with? (str path) ".clj"))
 
 (defn cljc-path? [path]
-  (boolean (re-find #"\.cljc$" (str path))))
+  (str/ends-with? (str path) ".cljc"))
 
 (defn cljs-path? [path]
-  (boolean (re-find #"\.cljs$" (str path))))
+  (str/ends-with? (str path) ".cljs"))
 
 (defn clj*-path? [path]
   (or (clj-path? path)
@@ -625,10 +625,15 @@
       (cljs-path? path)))
 
 (defn js-path? [path]
-  (re-find #"\.js$" (str path)))
+  (str/ends-with? (str path) ".js"))
 
-(defn test-path? [path]
-  (boolean (re-find #"_test\.cljc?$" (str path))))
+(defn test-path?
+  "True for .clj or .cljc test files (path ends with _test.clj or _test.cljc).
+  Excludes .cljs tests because clojure_test only runs on the JVM."
+  [path]
+  (let [s (str path)]
+    (or (str/ends-with? s "_test.clj")
+        (str/ends-with? s "_test.cljc"))))
 
 (defn src-path? [path]
   (not (test-path? path)))
@@ -681,7 +686,6 @@
        (filter (fn [p]
                  (.startsWith ^Path path ^Path (fs/->path deps-edn-dir p))))
        first))
-
 
 (s/fdef ns-rules :args (s/cat :a (s/keys :req-un [::basis ::deps-edn-dir ::jar->lib ::deps-bazel]) :p (s/coll-of fs/path?)))
 (defn ns-rules
@@ -789,6 +793,38 @@
   [{:keys [type attrs]}]
   (emit-bazel (list (symbol (name type)) (kwargs attrs))))
 
+(defn rollup-rules
+  "Build the __clj_lib + __clj_files rule specs for a package.
+
+  Inputs (all sequential):
+    :lib-deps               local target names in this package (rule names, e.g. [\"core\" \"util\"])
+    :src-files              resource filenames in this package (basenames, e.g. [\"core.clj\" \"util.cljs\"])
+    :clojure-subdir-paths   workspace-relative subdir paths whose rollup
+                            should be included (e.g. [\"src/example/child\"])
+
+  Returns a vector of {:type :attrs} specs in the order
+    [clojure_library/__clj_lib, filegroup/__clj_files]
+  emitting either / both / neither depending on whether the relevant inputs
+  are non-empty. Empty when none of lib-deps, src-files, subdir-paths are
+  present."
+  [{:keys [lib-deps src-files clojure-subdir-paths]}]
+  (let [subdir-lib-deps   (mapv #(str "//" % ":__clj_lib") clojure-subdir-paths)
+        subdir-file-deps  (mapv #(str "//" % ":__clj_files") clojure-subdir-paths)
+        local-lib-deps    (mapv #(str ":" %) lib-deps)
+        clj-lib-deps      (into local-lib-deps subdir-lib-deps)
+        clj-files-srcs    (vec src-files)]
+    (cond-> []
+      (seq clj-lib-deps)
+      (conj {:type :clojure_library
+             :attrs {:name "__clj_lib"
+                     :deps clj-lib-deps}})
+
+      (or (seq clj-files-srcs) (seq subdir-file-deps))
+      (conj {:type :filegroup
+             :attrs (cond-> {:name "__clj_files"}
+                      (seq clj-files-srcs) (assoc :srcs clj-files-srcs)
+                      (seq subdir-file-deps) (assoc :data subdir-file-deps))}))))
+
 (s/fdef gen-dir :args (s/cat :a (s/keys :req-un [::deps-edn-dir ::basis ::jar->lib ::deps-repo-tag]) :f fs/path?))
 (defn gen-dir
   "given a source directory, write a BUILD.bazel for all .clj files in the directory. non-recursive"
@@ -818,6 +854,10 @@
                      (group-by fs/basename)
                      (mapcat (fn [[_base paths]]
                                (ns-rules args paths)))))
+        rollup-specs (rollup-rules
+                      {:lib-deps             (distinct (map fs/basename paths))
+                       :src-files            (mapv fs/filename paths)
+                       :clojure-subdir-paths (mapv #(str (fs/path-relative-to deps-edn-dir %)) clj-subdirs)})
         has-content? (or (seq paths) (seq clj-subdirs))
         content (str (build-file-header "the `//:gen_srcs` target from `rules_clojure`")
                      (when has-content?
@@ -830,26 +870,13 @@
                      "\n"
                      (when (seq rules)
                        (str "\n" (str/join "\n\n" rules) "\n"))
-                     (when has-content?
-                       (str "\n"
-                            (emit-bazel (list 'clojure_library (kwargs {:name "__clj_lib"
-                                                                        :deps (vec
-                                                                               (concat
-                                                                                (distinct (map (fn [p] (str ":" (fs/basename p))) paths))
-                                                                                (map (fn [p]
-                                                                                       (str "//" (fs/path-relative-to deps-edn-dir p) ":__clj_lib")) clj-subdirs)))})))
-                            "\n\n"
-                            (emit-bazel (list 'filegroup (kwargs (merge
-                                                                  {:name "__clj_files"
-                                                                   :srcs (mapv fs/filename paths)
-                                                                   :data (mapv (fn [p]
-                                                                                 (str "//" (fs/path-relative-to deps-edn-dir p) ":__clj_files")) clj-subdirs)}))))
-                            "\n")))]
-    (let [build-file (-> dir (fs/->path "BUILD.bazel") fs/path->file)
-          changed? (not= content (when (.exists build-file) (slurp build-file :encoding "UTF-8")))]
-      (when changed?
-        (spit build-file content :encoding "UTF-8"))
-      {:files (count paths) :wrote (if changed? 1 0)})))
+                     (when (seq rollup-specs)
+                       (str "\n" (str/join "\n\n" (map emit-rule rollup-specs)) "\n")))
+        build-file (-> dir (fs/->path "BUILD.bazel") fs/path->file)
+        changed? (not= content (when (.exists build-file) (slurp build-file :encoding "UTF-8")))]
+    (when changed?
+      (spit build-file content :encoding "UTF-8"))
+    {:files (count paths) :wrote (if changed? 1 0)}))
 
 (s/fdef gen-source-paths- :args (s/cat :a (s/keys :req-un [::deps-edn-dir ::src-ns->label ::dep-ns->label ::jar->lib ::deps-bazel]) :paths (s/coll-of fs/path?)))
 (defn gen-source-paths-
@@ -932,62 +959,62 @@
   (spit (-> (fs/->path deps-build-dir "BUILD.bazel") fs/path->file)
         (str (build-file-header "`rules_clojure`")
              (str/join "\n\n" (concat
-                          [(emit-bazel (list 'load "@rules_clojure//:rules.bzl" "clojure_library"))
-                           (emit-bazel (list 'package (kwargs {:default_visibility ["//visibility:public"]})))]
-                          (->> jar->lib
-                               (sort-by (fn [[k v]] (library->label v)))
-                               (mapcat (fn [[jarpath lib]]
-                                         (let [label (library->label lib)
-                                               deps (->> (get lib->deps lib)
-                                                         (mapv (fn [lib]
-                                                                 (str ":" (library->label lib)))))
-                                               external-label (jar->label (select-keys args [:jar->lib]) jarpath)
-                                               extra-args (-> deps-bazel
-                                                              (get-in [:deps external-label]))
-                                               _ (assert (re-find #".jar$" (str jarpath)) "only know how to handle jars for now")
-                                               jarfile (JarFile. (fs/path->file jarpath))]
-                                           (vec
-                                            (concat
-                                             [(emit-bazel (list 'java_import (kwargs (merge-with into
-                                                                                                 {:name label
-                                                                                                  :jars [(fs/path-relative-to deps-build-dir jarpath)]}
-                                                                                                 (when (seq deps)
-                                                                                                   {:deps deps
-                                                                                                    :runtime_deps deps})
-                                                                                                 extra-args))))]
-                                             (->>
+                               [(emit-bazel (list 'load "@rules_clojure//:rules.bzl" "clojure_library"))
+                                (emit-bazel (list 'package (kwargs {:default_visibility ["//visibility:public"]})))]
+                               (->> jar->lib
+                                    (sort-by (fn [[k v]] (library->label v)))
+                                    (mapcat (fn [[jarpath lib]]
+                                              (let [label (library->label lib)
+                                                    deps (->> (get lib->deps lib)
+                                                              (mapv (fn [lib]
+                                                                      (str ":" (library->label lib)))))
+                                                    external-label (jar->label (select-keys args [:jar->lib]) jarpath)
+                                                    extra-args (-> deps-bazel
+                                                                   (get-in [:deps external-label]))
+                                                    _ (assert (re-find #".jar$" (str jarpath)) "only know how to handle jars for now")
+                                                    jarfile (JarFile. (fs/path->file jarpath))]
+                                                (vec
+                                                 (concat
+                                                  [(emit-bazel (list 'java_import (kwargs (merge-with into
+                                                                                                      {:name label
+                                                                                                       :jars [(fs/path-relative-to deps-build-dir jarpath)]}
+                                                                                                      (when (seq deps)
+                                                                                                        {:deps deps
+                                                                                                         :runtime_deps deps})
+                                                                                                      extra-args))))]
+                                                  (->>
                                                ;; TODO: Update to tools.namespace 1.4.1 which has metadata of the source path on the ns-decl so this dance isn't needed.
-                                              (find/sources-in-jar jarfile find/clj)
-                                              (keep
-                                               (fn [^JarEntry entry]
-                                                 (when-let [ns-decl (find/read-ns-decl-from-jarfile-entry jarfile entry find/clj)]
-                                                   (when (ns-matches-path? (parse/name-from-ns-decl ns-decl) (.getRealName entry))
-                                                     ns-decl))))
-                                              (filter
-                                               (fn [ns-decl]
-                                                 (should-compile-namespace? deps-bazel jarpath (parse/name-from-ns-decl ns-decl))))
-                                              (group-by parse/name-from-ns-decl)
-                                              (map (fn [[ns ns-decls]]
-                                                     (let [extra-deps (-> deps-bazel (get-in [:deps (str (when deps-repo-tag (str deps-repo-tag "//")) ":" (internal-dep-ns-aot-label lib ns))]))]
-                                                       (emit-bazel (list 'clojure_library (kwargs (->
-                                                                                                   (merge-with
-                                                                                                    into
-                                                                                                    {:name (internal-dep-ns-aot-label lib ns)
-                                                                                                     :aot [(str ns)]
-                                                                                                     :deps [(str (when deps-repo-tag (str deps-repo-tag "//")) ":" label)
-                                                                                                            (str (when deps-repo-tag (str deps-repo-tag "//")) ":org_clojure_clojure")]
+                                                   (find/sources-in-jar jarfile find/clj)
+                                                   (keep
+                                                    (fn [^JarEntry entry]
+                                                      (when-let [ns-decl (find/read-ns-decl-from-jarfile-entry jarfile entry find/clj)]
+                                                        (when (ns-matches-path? (parse/name-from-ns-decl ns-decl) (.getRealName entry))
+                                                          ns-decl))))
+                                                   (filter
+                                                    (fn [ns-decl]
+                                                      (should-compile-namespace? deps-bazel jarpath (parse/name-from-ns-decl ns-decl))))
+                                                   (group-by parse/name-from-ns-decl)
+                                                   (map (fn [[ns ns-decls]]
+                                                          (let [extra-deps (-> deps-bazel (get-in [:deps (str (when deps-repo-tag (str deps-repo-tag "//")) ":" (internal-dep-ns-aot-label lib ns))]))]
+                                                            (emit-bazel (list 'clojure_library (kwargs (->
+                                                                                                        (merge-with
+                                                                                                         into
+                                                                                                         {:name (internal-dep-ns-aot-label lib ns)
+                                                                                                          :aot [(str ns)]
+                                                                                                          :deps [(str (when deps-repo-tag (str deps-repo-tag "//")) ":" label)
+                                                                                                                 (str (when deps-repo-tag (str deps-repo-tag "//")) ":org_clojure_clojure")]
                                                                                                         ;; TODO the source jar doesn't need to be in runtime_deps
-                                                                                                     :runtime_deps []}
-                                                                                                    (apply merge-with into (map #(ns-deps (select-keys args [:dep-ns->label :jar->lib :deps-repo-tag]) % :clj) ns-decls))
-                                                                                                    extra-deps)
-                                                                                                   (as-> m
-                                                                                                         (cond-> m
-                                                                                                           (seq (:deps m)) (update :deps (comp vec distinct))
-                                                                                                           (:deps m) (update :deps (comp vec distinct))))))))))))))))))
-                          [(emit-bazel (list 'java_library (kwargs
-                                                            {:name "__all"
-                                                             :runtime_deps (->> jar->lib
-                                                                                (mapv (comp library->label val)))})))]))
+                                                                                                          :runtime_deps []}
+                                                                                                         (apply merge-with into (map #(ns-deps (select-keys args [:dep-ns->label :jar->lib :deps-repo-tag]) % :clj) ns-decls))
+                                                                                                         extra-deps)
+                                                                                                        (as-> m
+                                                                                                              (cond-> m
+                                                                                                                (seq (:deps m)) (update :deps (comp vec distinct))
+                                                                                                                (:deps m) (update :deps (comp vec distinct))))))))))))))))))
+                               [(emit-bazel (list 'java_library (kwargs
+                                                                 {:name "__all"
+                                                                  :runtime_deps (->> jar->lib
+                                                                                     (mapv (comp library->label val)))})))]))
              "\n")
 
         :encoding "UTF-8"))

--- a/test/rules_clojure/BUILD
+++ b/test/rules_clojure/BUILD
@@ -71,6 +71,10 @@ clojure_test(name="gen-build-test",
              env={"BUILDIFIER": "$(rlocationpath @buildifier_prebuilt//:buildifier)"},
              test_ns = "rules-clojure.gen-build-test")
 
+clojure_test(name="gazelle-server-test",
+             deps=[":test-deps"],
+             test_ns = "rules-clojure.gazelle-server-test")
+
 clojure_test(name="compile-test",
              deps=[":test-deps",
                    ":aot-only-fixture",

--- a/test/rules_clojure/gazelle_server_test.clj
+++ b/test/rules_clojure/gazelle_server_test.clj
@@ -1,0 +1,266 @@
+(ns rules-clojure.gazelle-server-test
+  (:require [clojure.test :refer :all]
+            [clojure.data.json :as json]
+            [clojure.string :as str]
+            [rules-clojure.fs :as fs]
+            [rules-clojure.gazelle-server :as gs])
+  (:import (java.io BufferedReader BufferedWriter File StringReader StringWriter)))
+
+(defn- parse-state-for
+  "Build a handle-parse state with :basis / :deps-edn-dir wired to `dir`
+  so gen-build/strip-path (called from ns-rules) finds a match. Empty
+  string in :paths joins to deps-edn-dir itself — Java Path startsWith
+  is element-wise, so :paths [\".\"] would NOT match abs files under
+  deps-edn-dir."
+  [^File dir]
+  {:jar->lib      {}
+   :class->jar    {}
+   :deps-repo-tag "@deps"
+   :dep-ns->label {}
+   :deps-bazel    {}
+   :basis         {:paths [""]}
+   :deps-edn-dir  (fs/->path (.getAbsolutePath dir))})
+
+(defmacro with-temp-dir
+  "Bind `dir-sym` to a fresh `File` temp directory for `body`. Recursively
+   deletes the directory on exit."
+  [[dir-sym prefix] & body]
+  `(let [path# (fs/new-temp-dir ~prefix)
+         ~(vary-meta dir-sym assoc :tag `File) (.toFile path#)]
+     (try ~@body
+          (finally (fs/rm-rf path#)))))
+
+(defn- write-clj!
+  "Write a .clj file into dir with the given filename and content string."
+  [^File dir filename content]
+  (let [f (File. dir filename)]
+    (spit f content)
+    f))
+
+(deftest read-request-parses-json-line
+  (let [input "{\"type\":\"init\",\"count\":42}\n"
+        reader (BufferedReader. (StringReader. input))
+        result (gs/read-request reader)]
+    (is (= {:type "init" :count 42} result))
+    (is (keyword? (first (keys result))))))
+
+(deftest read-request-returns-nil-on-eof
+  (let [reader (BufferedReader. (StringReader. ""))]
+    (is (nil? (gs/read-request reader)))))
+
+(deftest write-response-produces-json-line
+  (let [sw (StringWriter.)
+        writer (BufferedWriter. sw)]
+    (gs/write-response writer {:type "init" :data [1 2 3]})
+    (let [output (.toString sw)
+          parsed (json/read-str (str/trim output) :key-fn keyword)]
+      (is (str/ends-with? output "\n"))
+      (is (= "init" (:type parsed)))
+      (is (= [1 2 3] (:data parsed))))))
+
+(deftest write-then-read-roundtrips-multiple-messages
+  (testing "writer/reader pair can interleave multiple lines without loss"
+    (let [sw (StringWriter.)
+          writer (BufferedWriter. sw)]
+      (gs/write-response writer {:type "init" :a 1})
+      (gs/write-response writer {:type "parse" :b 2})
+      (let [reader (BufferedReader. (StringReader. (.toString sw)))]
+        (is (= {:type "init" :a 1} (gs/read-request reader)))
+        (is (= {:type "parse" :b 2} (gs/read-request reader)))
+        (is (nil? (gs/read-request reader)))))))
+
+(deftest strip-leading-colon-handles-both-prefixes
+  (testing "aliases may arrive with or without a leading colon. The helper
+  strips a single leading colon so `(keyword (strip-leading-colon \":foo\"))`
+  produces :foo and not the malformed :' :foo'."
+    (is (= "foo"  (#'gs/strip-leading-colon "foo")))
+    (is (= "bar"  (#'gs/strip-leading-colon ":bar")))
+    (is (= "test" (#'gs/strip-leading-colon ":test")))
+    (is (= ""     (#'gs/strip-leading-colon "")))))
+
+;; init-state's full pipeline is exercised by gazelle/clojureparser/parser_test.go
+;; (TestInitRoundTrip) — it boots the real subprocess against a fixture deps.edn
+;; once the deploy jar and its Maven dependencies are available.
+
+(deftest handle-parse-clj-file
+  (testing "parse handler extracts namespace info from a .clj file"
+    (with-temp-dir [dir "gazelle-parse-test-"]
+      (write-clj! dir "core.clj"
+                  "(ns my.core (:require [clojure.string :as str] [clojure.set]))")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["core.clj"]})]
+        (is (= "parse" (:type resp)))
+        (is (= 1 (count (:namespaces resp))))
+        (let [ns-info (first (:namespaces resp))]
+          (is (= "my.core" (:ns ns-info)))
+          (is (= "core.clj" (:file ns-info)))
+          (is (= ["clj"] (:platforms ns-info)))
+          (is (contains? (:requires ns-info) "clj"))
+          (is (contains? (set (get-in ns-info [:requires "clj"])) "clojure.string"))
+          (is (contains? (set (get-in ns-info [:requires "clj"])) "clojure.set")))))))
+
+(deftest handle-parse-cljc-file
+  (testing "parse handler reports both platforms for .cljc"
+    (with-temp-dir [dir "gazelle-parse-cljc-"]
+      (write-clj! dir "util.cljc" "(ns my.util)")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["util.cljc"]})
+            ns-info (first (:namespaces resp))]
+        (is (= 1 (count (:namespaces resp))))
+        (is (= "my.util" (:ns ns-info)))
+        (is (= ["clj" "cljs"] (:platforms ns-info)))))))
+
+(deftest handle-parse-js-files
+  (testing "parse handler returns minimal entries for .js files"
+    (with-temp-dir [dir "gazelle-parse-js-"]
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["app.js" "lib.js"]})]
+        (is (= "parse" (:type resp)))
+        (is (= 2 (count (:namespaces resp))))
+        (is (every? #(= ["js"] (:platforms %)) (:namespaces resp)))
+        (is (= #{"app.js" "lib.js"} (set (map :file (:namespaces resp)))))))))
+
+(deftest handle-parse-mixed-files
+  (testing "parse handler handles clj and js files together"
+    (with-temp-dir [dir "gazelle-parse-mixed-"]
+      (write-clj! dir "core.clj" "(ns mixed.core)")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["core.clj" "bundle.js"]})
+            by-file (into {} (map (juxt :file identity) (:namespaces resp)))]
+        (is (= 2 (count (:namespaces resp))))
+        (is (= "mixed.core" (:ns (get by-file "core.clj"))))
+        (is (= ["clj"] (:platforms (get by-file "core.clj"))))
+        (is (= ["js"] (:platforms (get by-file "bundle.js"))))))))
+
+;; Per-namespace ns_meta is no longer a top-level wire field — gen-build/ns-rules
+;; merges it into the clojure_library rule's attrs (e.g. ns_library_meta keys
+;; like :aot end up in :attrs "aot"). gen_build_test covers that directly.
+
+;; Per-namespace import_deps are merged into the clojure_library rule's :deps
+;; by gen-build/ns-rules using state[:class->jar / :jar->lib / :deps-repo-tag].
+;; The exact label format (e.g. "@deps//:_maven___java_runtime") is gen-build's
+;; concern and is tested at that layer, not on the wire.
+
+(deftest handle-parse-returns-error-entry-on-parse-failure
+  (testing "syntactically broken .clj produces a tagged error rather than silent []"
+    (with-temp-dir [dir "gazelle-parse-broken-"]
+      (write-clj! dir "broken.clj" "(ns my.broken (:require [foo (")  ; unbalanced
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["broken.clj"]})
+            entries (:namespaces resp)]
+        (is (= 1 (count entries)))
+        (is (some? (:error (first entries)))
+            "parse failure must surface as :error so the Go side can abort")))))
+
+(deftest handle-parse-no-ns-form-returns-empty
+  (testing "resource-only .clj (no ns form) yields no namespace entry"
+    (with-temp-dir [dir "gazelle-parse-no-ns-"]
+      (write-clj! dir "data.clj" "{:reader 'foo}")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["data.clj"]})]
+        (is (zero? (count (:namespaces resp))))))))
+
+(deftest handle-request-rejects-parse-before-init
+  (testing "parse before init returns an error envelope, not silent empty"
+    (let [state (atom nil)
+          response (gs/handle-request state {:type "parse" :dir "/" :files []})]
+      (is (= "error" (:type response)))
+      (is (str/includes? (:message response) "init")))))
+
+(deftest handle-request-rejects-unknown-type
+  (let [state (atom nil)
+        response (gs/handle-request state {:type "wat"})]
+    (is (= "error" (:type response)))
+    (is (str/includes? (:message response) "unknown"))))
+
+(deftest handle-parse-rollup-rules-clj-only
+  (testing "rollup_rules emits __clj_lib with the local rule name (not nil)
+  when the package has clojure_library content. Regression for the wire-
+  shape bug where lib-names was computed against keyword keys on a
+  stringified-attr map and returned [nil]."
+    (with-temp-dir [dir "gazelle-rollup-clj-"]
+      (write-clj! dir "core.clj" "(ns my.core)")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["core.clj"]})
+            rollups (:rollup_rules resp)
+            by-name (into {} (map (juxt #(get-in % [:attrs "name"]) identity) rollups))]
+        (is (= 2 (count rollups))
+            "__clj_lib + __clj_files emitted when local clojure_library exists")
+        (is (= ["clojure_library" "filegroup"] (sort (map :kind rollups))))
+        (let [lib (get by-name "__clj_lib")]
+          (is (= "clojure_library" (:kind lib)))
+          (is (= [":core"] (get-in lib [:attrs "deps"]))
+              "__clj_lib deps reference the local rule by basename (no extension), not nil"))
+        (let [files (get by-name "__clj_files")]
+          (is (= "filegroup" (:kind files)))
+          (is (= ["core.clj"] (get-in files [:attrs "srcs"]))))))))
+
+(deftest handle-parse-rollup-rules-with-subdirs
+  (testing "rollup_rules includes subdir labels passed via clojure_subdir_paths
+  even when the package has no local Clojure files of its own."
+    (with-temp-dir [dir "gazelle-rollup-subdirs-"]
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir)
+                                   :files []
+                                   :clojure_subdir_paths ["src/foo"]})
+            rollups (:rollup_rules resp)
+            by-name (into {} (map (juxt #(get-in % [:attrs "name"]) identity) rollups))]
+        (is (= 2 (count rollups))
+            "__clj_lib + __clj_files emitted from subdirs alone")
+        (is (= ["//src/foo:__clj_lib"] (get-in by-name ["__clj_lib" :attrs "deps"])))
+        (is (= ["//src/foo:__clj_files"] (get-in by-name ["__clj_files" :attrs "data"])))))))
+
+(deftest handle-parse-rollup-rules-empty
+  (testing "rollup_rules is empty when no local content and no subdirs."
+    (with-temp-dir [dir "gazelle-rollup-empty-"]
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files []})]
+        (is (= [] (:rollup_rules resp)))))))
+
+(deftest handle-parse-js-only-rules-populated
+  (testing "JS-only groups still emit a :rules vector via ns-rules so the
+  Go side can build a java_library."
+    (with-temp-dir [dir "gazelle-js-rules-"]
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["lib.js"]})
+            ns-info (first (:namespaces resp))]
+        (is (= 1 (count (:namespaces resp))))
+        (is (= ["js"] (:platforms ns-info)))
+        (is (seq (:rules ns-info)) "JS-only entry must have a :rules vector")
+        (is (= "java_library" (-> ns-info :rules first :kind)))))))
+
+(deftest handle-parse-cljs-with-resource-only-clj-partner
+  (testing "Resource-only .clj paired with .cljs that declares ns: surface the
+  cljs ns instead of silently dropping the rule because primary (clj) had no
+  ns form. Regression for the resource-only-drops-cljs bug."
+    (with-temp-dir [dir "gazelle-cljs-partner-"]
+      (write-clj! dir "shared.clj"  "{:reader 'foo}")     ; resource-only
+      (write-clj! dir "shared.cljs" "(ns my.shared)")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir) :files ["shared.clj" "shared.cljs"]})
+            ns-info (first (:namespaces resp))]
+        (is (= 1 (count (:namespaces resp))))
+        (is (= "my.shared" (:ns ns-info)))
+        (is (contains? (set (:platforms ns-info)) "cljs"))))))
+
+(deftest handle-parse-namespaces-deterministic-order
+  (testing "Namespaces emitted in sorted-by-basename order so BUILD diffs are
+  stable across runs."
+    (with-temp-dir [dir "gazelle-order-"]
+      (write-clj! dir "z_last.clj"  "(ns my.z)")
+      (write-clj! dir "a_first.clj" "(ns my.a)")
+      (write-clj! dir "m_mid.clj"   "(ns my.m)")
+      (let [resp (gs/handle-parse (parse-state-for dir)
+                                  {:dir (str dir)
+                                   :files ["z_last.clj" "a_first.clj" "m_mid.clj"]})]
+        (is (= ["a_first.clj" "m_mid.clj" "z_last.clj"]
+               (mapv :file (:namespaces resp))))))))
+
+(deftest handle-parse-rejects-malformed-request
+  (testing "handle-parse validates the request shape and throws ex-info on
+  malformed inputs instead of crashing with cryptic ClassCastExceptions."
+    (let [state (parse-state-for (.toFile (fs/new-temp-dir "gazelle-malformed-")))]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (gs/handle-parse state {:dir 42 :files []})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (gs/handle-parse state {:dir "/tmp" :files "not-a-vec"}))))))

--- a/test/rules_clojure/gen_build_test.clj
+++ b/test/rules_clojure/gen_build_test.clj
@@ -349,3 +349,55 @@
           "should emit __clj_lib aggregating subdirs")
       (is (re-find #"\"//src/example/child:__clj_lib\"" content)
           "__clj_lib deps should reference the clj subdir"))))
+
+(deftest test-path?-recognizes-clj-and-cljc-only
+  (testing "anchored .clj/.cljc test suffix"
+    (is (gb/test-path? "core_test.clj"))
+    (is (gb/test-path? "core_test.cljc"))
+    (is (gb/test-path? "/abs/path/foo_test.clj"))
+    (is (gb/test-path? (fs/->path "core_test.clj"))))
+  (testing ".cljs tests are intentionally excluded"
+    (is (not (gb/test-path? "core_test.cljs"))))
+  (testing "anchored — substring matches do not count"
+    (is (not (gb/test-path? "core_test.clj.bak")))
+    (is (not (gb/test-path? "_test.clj.swp"))))
+  (testing "non-test files"
+    (is (not (gb/test-path? "core.clj")))
+    (is (not (gb/test-path? "test.clj")))
+    (is (not (gb/test-path? "test_core.clj")))))
+
+(deftest rollup-rules-empty-inputs
+  (testing "no libs, no files, no subdirs → no rules"
+    (is (empty? (gb/rollup-rules {})))
+    (is (empty? (gb/rollup-rules {:lib-deps [] :src-files [] :clojure-subdir-paths []})))))
+
+(deftest rollup-rules-libs-only
+  (let [out (gb/rollup-rules {:lib-deps ["core" "util"]
+                              :src-files ["core.clj" "util.cljs"]
+                              :clojure-subdir-paths []})
+        kinds (mapv :type out)]
+    (is (= [:clojure_library :filegroup] kinds))
+    (is (= [":core" ":util"] (get-in (first out) [:attrs :deps])))
+    (is (= ["core.clj" "util.cljs"] (get-in (second out) [:attrs :srcs])))
+    (is (nil? (get-in (second out) [:attrs :data])))))
+
+(deftest rollup-rules-subdirs-only
+  (let [out (gb/rollup-rules {:lib-deps []
+                              :src-files []
+                              :clojure-subdir-paths ["src/example/child"]})]
+    (is (= [:clojure_library :filegroup] (mapv :type out)))
+    (is (= ["//src/example/child:__clj_lib"] (get-in (first out) [:attrs :deps])))
+    (is (= ["//src/example/child:__clj_files"] (get-in (second out) [:attrs :data])))
+    (is (nil? (get-in (second out) [:attrs :srcs])))))
+
+(deftest rollup-rules-mixed
+  (let [out (gb/rollup-rules {:lib-deps ["webauthn"]
+                              :src-files ["webauthn.clj" "webauthn.cljs"]
+                              :clojure-subdir-paths ["src/example/api" "src/example/db"]})
+        clj-lib (first out)
+        clj-files (second out)]
+    (is (= [":webauthn" "//src/example/api:__clj_lib" "//src/example/db:__clj_lib"]
+           (get-in clj-lib [:attrs :deps])))
+    (is (= ["webauthn.clj" "webauthn.cljs"] (get-in clj-files [:attrs :srcs])))
+    (is (= ["//src/example/api:__clj_files" "//src/example/db:__clj_files"]
+           (get-in clj-files [:attrs :data])))))


### PR DESCRIPTION
## Background

Bazel reads `BUILD.bazel` files to figure out what to build. In a large Clojure repo those files describe every `clojure_library` / `clojure_test` / `clojure_binary` target plus the deps between them. Hand-maintaining them at scale is impractical, so we generate them from the source tree.

We've been doing that with **`gen_srcs`** — a standalone `bazel run` target. You invoke it manually; it walks the repo, parses every Clojure namespace, computes deps, and writes BUILD files. It works, but it's outside the normal Bazel lifecycle: no incremental updates, no directives to control behavior per package, no way to interop with other languages also generating BUILD files in the same repo.

This PR replaces `gen_srcs` with a proper **[Gazelle](https://github.com/bazelbuild/bazel-gazelle)** plugin.

### What's Gazelle?

Gazelle is a BUILD-file generator that runs as a Bazel build target. You write a **language plugin** (in Go — Gazelle's own implementation language) that tells it how to find your source files and what rules to emit. Gazelle handles the rest: directory walk, BUILD-file parsing, rule merging, cross-package dep resolution. Most modern Bazel rule sets ship a Gazelle plugin (Go, Java, Python, Rust, etc.) so users can keep their BUILD files in sync with one command.

### Why a subprocess?

Gazelle plugins are Go code. But all our existing rule-construction logic — AOT decisions, test-attr passthrough, dep label generation — is in Clojure (`rules-clojure.gen-build`). Rewriting it in Go would mean two implementations of the same rules; they'd drift, and bugs in one wouldn't be caught by the other.

Instead, this plugin follows the [Java Gazelle plugin](https://github.com/bazel-contrib/rules_jvm/tree/main/java/gazelle) architecture: the Go side is just glue — it starts a long-running Clojure subprocess and asks it questions over stdio. The Clojure side owns the rules.

```mermaid
flowchart LR
    Bazel[bazel run //:gazelle] --> Plugin[Go plugin<br/>gazelle/]
    Plugin <-->|JSON lines<br/>on stdio| Server[Clojure server<br/>gazelle_server.clj]
    Server --> GenBuild[rules-clojure.gen-build<br/>shared with gen_srcs]
    Plugin --> Builds[BUILD.bazel files]
```

## Life of a Gazelle run

Gazelle walks the repo top-down, calling four hook points on every package it visits. Our plugin implements all four:

```mermaid
sequenceDiagram
    participant G as Gazelle
    participant P as Go plugin
    participant S as Clojure server

    Note over G,S: Once per run, at startup
    G->>P: Configure(root)
    P->>S: spawn subprocess
    P->>S: {type:"init", deps_edn_path, ...}
    S-->>P: {dep_ns_labels, deps_bazel, source_paths, ...}

    Note over G,S: Once per package, bottom-up
    G->>P: Configure(pkg)
    P->>P: record per-package directives

    G->>P: GenerateRules(pkg)
    P->>S: {type:"parse", dir, files, clojure_subdir_paths}
    S->>S: read each (ns ...) form
    S->>S: call gen-build/ns-rules
    S-->>P: {namespaces, rollup_rules}
    P-->>G: clojure_library / clojure_test / __clj_lib / __clj_files

    Note over G,S: After all GenerateRules done
    G->>P: Resolve(rule)
    P->>P: intra-repo lookup + dep_ns_labels + deps_bazel
    P-->>G: rule.deps = [...]

    Note over G,S: At shutdown
    G->>P: AfterResolvingDeps
    P->>S: close stdin
    S-->>P: exits
```

| Hook | Job |
|---|---|
| **Configure** | Read per-package `# gazelle:` directives. On the root call, auto-discover `deps.edn` + `MODULE.bazel` and start the Clojure subprocess. |
| **GenerateRules** | RPC the Clojure server with the package's file list. Translate the returned `{kind, attrs}` specs into Gazelle `*rule.Rule` objects. |
| **Resolve** | For each emitted `clojure_library`, walk its `:require`s and fill in the rule's `:deps` against the cross-package index Gazelle built during indexing. |
| **AfterResolvingDeps** | Shut the subprocess down cleanly. |

## Wire protocol

The Clojure server speaks **newline-delimited JSON** on stdio. One request per line, one response per line. Two request types:

| Request | When | Response |
|---|---|---|
| `init` | Once at startup | Resolved dep graph (`dep_ns_labels`), `deps_bazel` overrides, ignore/source paths |
| `parse` | Once per package | Per-namespace info (file, requires per platform, emitted rules) + the `__clj_lib` / `__clj_files` rollup rules |

A typed Go envelope embeds an optional `message` field so Init/Parse decode in a single `json.Unmarshal` pass — the same payload doesn't get parsed twice when `dep_ns_labels` is multi-MB. Malformed JSON surfaces with the `json.SyntaxError` offset and a window of bytes around it so big-response debugging isn't reduced to "first 200 bytes".

### Why JSON over stdio (and not gRPC, sockets, etc.)

- **Zero setup.** No port allocation, no service discovery, no auth. Subprocess starts, pipes wired.
- **Crash-safe.** If the subprocess dies, the Go side sees EOF and `log.Fatalf`s immediately. No half-alive runner racing the next request.
- **Easy to debug.** You can `bazel run //src/rules_clojure:gazelle_server` by hand and paste JSON at it.

## Architecture: Clojure owns the rules

Rule construction lives in `rules-clojure.gen-build`, not in Go. That includes:

- AOT-vs-plain library decisions (`:bazel/clojure_library` metadata on the `ns` form)
- Test attr passthrough (`:bazel/clojure_test` for size/tags/timeout)
- Per-namespace `:require` → dep label mapping
- `clojure_binary` emission for `:bazel/clojure_binary` metadata
- `java_library` for `.js` files alongside `.cljs`
- `__clj_lib` / `__clj_files` rollup composition

The Go side calls `gen-build/ns-rules` per basename group and `gen-build/rollup-rules` per package; both return `[{:type :clojure_library :attrs {...}} ...]` Clojure data. Go translates verbatim into Gazelle `*rule.Rule` via `buildRule` + `applyAttr`. Same Clojure code drives both `gen_srcs` and the plugin — one source of truth.

### What Go actually does

Three things only:

1. **Subprocess plumbing.** Start the server, marshal requests, parse responses, mark the runner dead on any I/O error so subsequent calls short-circuit instead of racing a corpse.
2. **Wire-format translation.** `{:type :clojure_library :attrs {:name "core" ...}}` → `rule.NewRule("clojure_library", "core")` + `r.SetAttr("name", "core")` etc.
3. **Dep resolution.** Per `clojure_library` rule, walk its `:require`s and resolve each to a Bazel label:
   - First try Gazelle's cross-package index (matches `(:require [my.foo])` to `//src/my:foo` when another package generated it).
   - Fall back to `init`'s `dep_ns_labels` map (Maven coords resolved at startup).
   - Add per-target overrides from `deps_bazel` (the user's `:bazel` map in `deps.edn`).
   - Sort and dedupe.

The static deps that don't need Gazelle's index (`org_clojure_clojure`, `clojure-library-args`, `ns-library-meta`, pre-resolved import-deps / gen-class-deps) are pre-merged Clojure-side and seeded into the dep set from the rule's existing `:deps`. Resolve only adds what genuinely needs the index.

## Configuration

Per-package directives in BUILD-file comments:

```python
# gazelle:clojure_enabled false        # skip this directory tree entirely
# gazelle:clojure_deps_edn deps.edn    # which deps.edn to use (default: root)
# gazelle:clojure_deps_repo @other     # use a different deps.bzl repo for external labels
# gazelle:clojure_aliases :dev,:test   # deps.edn aliases to activate at init time
```

Auto-discovered at startup:

- **`deps.edn`** at the workspace root (the source of dep coords).
- **`MODULE.bazel`** root module name — used to canonicalize self-referencing labels (`@<root>//foo` → `@@//foo`).

> [!IMPORTANT]
> **Migrating from `gen_srcs`?** `gen_srcs` takes aliases via CLI args (`:aliases [:bazel :cider :dev ...]`); the plugin reads them from a `# gazelle:clojure_aliases :bazel,:cider,:dev,...` directive in the **root** `BUILD.bazel`. **Without this directive the plugin starts with no aliases active**, which silently shrinks the basis and produces rules missing deps for namespaces that come from alias-gated artefacts (e.g. ClojureScript deps under a `:frontend` alias). Symptom: gazelle's output is missing `@deps//:org_clojure_clojurescript` on cross-platform rules. Fix: add the directive matching your old `gen_srcs` invocation.

## Failure semantics

Empty `GenerateResult` for a previously-rule-bearing package looks identical to Gazelle as "delete every rule". A green run that scorches the build graph is worse than a noisy exit, so the plugin **fails loud** on:

- Parser startup or transport errors
- Per-file Clojure parse exceptions (these come back as tagged `{:error :file}` entries — the Go side `log.Fatalf`s on receipt)
- Walk errors under `subdirHasClojureFiles` (permission denied, broken symlink, etc.)
- Malformed `deps_bazel` shapes (typed at the `json.Unmarshal` boundary, not via runtime type-asserts)
- Unknown rule kinds from the Clojure server (closed set: `clojure_library` / `clojure_test` / `clojure_binary` / `java_library` / `filegroup`)
- Missing `rules_clojure` `bazel_dep` in `MODULE.bazel`

On the Clojure side: the request loop catches `Throwable` (not just `Exception`) so `AssertionError` / `OutOfMemoryError` can't silently kill the subprocess, and the returned `:error` message includes the full exception cause-chain (class + message per link) so a wrapped `EOFException` doesn't collapse into a generic outer message.

Parse requests are validated against an `s/keys` spec at the server boundary, so a malformed wire payload returns a structured `{type:"error", message:"..."}` envelope instead of a cryptic `ClassCastException` deep in the parser pipeline.

## Subdir rollup cache

Each package emits a `__clj_lib` / `__clj_files` rollup that aggregates the package's own rules plus the rollups of any Clojure-bearing subdirectories. Naively that's an O(n) `WalkDir` per package — quadratic across the tree.

Instead, Gazelle's bottom-up walk lets us record `hasClojureContent[rel]` for each visited package and consult it as an O(1) lookup when the parent gets generated. Falls back to the on-disk walk for any subdir we somehow haven't visited yet (defensive — shouldn't happen in normal Gazelle ordering).

Intermediate-only directories (no direct `.clj`/`.cljs`/`.cljc`/`.js` files, but Clojure-bearing subdirs) still emit their rollup rules so consumers of `//foo:__clj_lib` keep working when `foo/` is an aggregator with code only in `foo/bar/`.

## Validation: byte-identical to gen_srcs

Verified against a large internal Clojure monorepo (~1300 BUILD files): the plugin produces byte-identical output to `gen_srcs` on every file `gen_srcs` touches.

The handful of remaining content diffs are in dirs `gen_srcs` ignores (`.circleci`, `test-data`, etc.) where Gazelle additionally cleans up stale `clojure_test` symbols from old `load(...)` statements — Gazelle being more thorough, not a bug.

## Build / module changes

| Change | Why |
|---|---|
| Add `bazel_dep(name = "rules_go", version = "0.60.0")` | Required for Gazelle plugins (Gazelle plugins are Go binaries). |
| Add `bazel_dep(name = "gazelle", version = "0.47.0")` | Gazelle itself. Pinned at 0.47.0 because 0.51.0 introduces a v2 module path that `go test` outside Bazel can't resolve cleanly. |
| `go_deps.from_file(go_mod = "//gazelle:go.mod")` | Wire the plugin's Go deps via the bzlmod extension. Replaces the old WORKSPACE `http_archive` setup — WORKSPACE was emptied by #79. |
| Delete `gazelle/deps.bzl` | WORKSPACE-era helper, dead under bzlmod. |
| Add `target/` to `.gitignore` | Go test artefacts. |
| `bootstrap_gazelle_server.clj` reuses `bootstrap_gen_build/nses-to-compile` | Single source of truth for the AOT'd namespaces in both deploy jars; one place to update when adding a tools.deps / namespace-reader dep. |
| `CLOJURE_MAVEN_REPOSITORY` env override | Lets CI / containers point at a pre-populated Maven cache without symlinking `$HOME/.m2`. |

## Wire types (`gazelle/clojureparser`)

| Type | Role |
|---|---|
| `Runner` | Owns the subprocess lifecycle (`exec.Cmd` + stdin/stdout pipes + a `bufio.Scanner` with a 10 MB line buffer). All methods serialize on an internal mutex; safe for concurrent use. |
| `InitRequest` / `InitResponse` | The startup handshake. Response carries `DepNsLabels` (Maven coord → Bazel label map), `DepsBazel` (per-target overrides), `IgnorePaths`, `SourcePaths`. |
| `ParseRequest` / `ParseResponse` | Per-directory request. Response carries one `NamespaceInfo` per basename group plus the rollup rules for the directory. |
| `RuleSpec` | A `{Kind, Attrs}` pair the Clojure server hands back. `Kind` is a closed set; `Attrs` is `map[string]interface{}` because the attr shape varies per kind. |
| `NamespaceInfo` | Per-group result: namespace symbol, primary file, requires per platform (`clj` / `cljs`), platforms set, rules to emit. `Error` is non-empty if the parse failed; `:require`s and `:ns` are absent for JS-only groups. |
| `DepsBazel` / `DepsBazelTarget` | Typed view of the user's `:bazel` map: `Deps map[label]DepsBazelTarget` where `DepsBazelTarget{Deps []string}` lists extra labels to merge into a target's `:deps`. Other keys under `:bazel` decode silently and stay inert. |

## Tests

### Go (`gazelle/`)

- **Wire-format translator**: `buildRule` / `applyAttr` happy path + unknown-kind, missing-name, non-string-name, nil-attr, and dict-valued-attr rejection.
- **Config tree walk**: per-package directive overrides, root-module-name discovery from `MODULE.bazel`.
- **`Imports`**: intra-repo lookup, AOT-fallback for pre-existing rules, multi-AOT (one `ImportSpec` per `aot` entry, not just `aot[0]`).
- **`mergeDepsBazelTargetDeps`**: absent, happy path, unmatched label.
- **`Configure` lifecycle**: root + sub-package, extension-disable directive, alias parsing.
- **Subprocess lifecycle** (`lifecycle_test.go`, against a shell-script stub): `Init` rejects malformed JSON, `Init` rejects error envelopes, exchange marks the runner dead on EOF + short-circuits subsequent calls with `ErrRunnerDead`, `Shutdown` is idempotent and safe on a nil receiver.
- **Integration round-trip** against the real deploy jar (`TestInitRoundTrip` / `TestParseRoundTrip`): gated on `GAZELLE_INTEGRATION_TEST_REQUIRED=1` so CI fails loud on a missing fixture instead of silently skipping. Locally the skip is the right behavior because the jar may not be built yet.

### Clojure (`test/rules_clojure/`)

- **Wire I/O** (`read-request` / `write-response`): JSON round-trip, EOF returns nil, multi-message stream.
- **`strip-leading-colon`**: handles `:foo` and `foo` shapes.
- **`handle-parse` per-platform**: `.clj`, `.cljc`, `.cljs`, JS-only, mixed clj+js basename collapse.
- **`handle-parse` error paths**: broken `.clj` returns tagged `:error` entry; resource-only `.clj` with no `(ns ...)` returns empty `:namespaces`; resource-only `.clj` paired with a declaring `.cljs` sibling surfaces the cljs namespace.
- **`handle-request` dispatch**: parse-before-init rejected with structured error; unknown request type rejected.
- **`__clj_lib` / `__clj_files` rollup**: clj-only, subdir-only, empty, JS-only `:rules` populated.
- **Deterministic namespace ordering** in the response (sorted by basename) so BUILD diffs are stable across runs.
- **Malformed request rejection** via `s/keys` spec validation.
- **`rollup-rules` unit tests** (`gen_build_test.clj`): empty, lib-only, subdirs-only, mixed.
- **`test-path?`** matrix: `.clj` / `.cljc` test files match, `.cljs` doesn't (clojure_test only runs on the JVM).

