### PR TITLE
tidy(gen_build): remove spec validation, dead code, use string predicates

### DIFF
--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -76,7 +76,6 @@
 
 (s/fdef kwargs :args (s/cat :x ::bazel-map) :ret kwargs?)
 (defn kwargs [x]
-  (validate! ::bazel-map x)
   (->KeywordArgs x))
 
 (s/def ::bazel-atom (s/or :s string? :k keyword? :p fs/path? :b boolean?))
@@ -140,7 +139,6 @@
 (defn emit-bazel
   "Given a string name and a dictionary of arguments, return a string of bazel"
   [x]
-  (validate! ::bazel x)
   (emit-bazel* x))
 
 (defn resolve-src-location
@@ -186,7 +184,7 @@
 (defn ->jar->lib
   "Return a map of jar path to library name ('org.clojure/clojure)"
   [basis]
-  {:post [(s/valid? ::jar->lib %)]}
+  {:post [(map? %)]}
   (->> basis
        :classpath
        (map (fn [[path {:keys [path-key lib-name]}]]
@@ -277,7 +275,7 @@
 (defn ->dep-ns->label [{:keys [basis deps-bazel deps-repo-tag] :as args}]
   {:pre [(map? basis)
          deps-bazel]
-   :post [(s/valid? ::dep-ns->label %)]}
+   :post [(map? %)]}
   (->> basis
        :classpath
        (map (fn [[path {:keys [lib-name]}]]
@@ -327,7 +325,7 @@
 (defn ->class->jar
   "returns a map of class symbol to jarpath for all jars on the classpath"
   [basis]
-  {:post [(s/valid? ::class->jar %)]}
+  {:post [(map? %)]}
   (into {}
         (mapcat
          (fn [path]
@@ -555,7 +553,7 @@
   Returns a vector of {:type keyword :attrs map} — pure data, no serialization."
   [{:keys [deps-bazel deps-repo-tag] :as args} paths]
   (assert (map? (:src-ns->label args)))
-  (assert (s/valid? (s/coll-of fs/path?) paths))
+  (assert (sequential? paths))
   (try
     (let [clj? (some clj-path? paths)
           cljc? (some cljc-path? paths)

--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -361,11 +361,6 @@
               ;; empty parent means this is a toplevel dep, already covered elsewhere
               dep-map))) {})))
 
-(s/fdef src->label :args (s/cat :a (s/keys :req-un [::deps-edn-dir]) :p fs/path?) :ret string?)
-(defn src->label [{:keys [deps-edn-dir]} path]
-  (let [path (fs/path-relative-to deps-edn-dir path)]
-    (str "//" (fs/dirname path) ":" (str (fs/basename path)))))
-
 (s/fdef jar->label :args (s/cat :a (s/keys :req-un [::jar->lib] :opt-un [::deps-repo-tag]) :p fs/path?) :ret string?)
 (defn jar->label
   "Given a .jar path, return the bazel label. `deps-repo-tag` is the name of the bazel repository where deps are held, e.g `@deps`"
@@ -473,37 +468,28 @@
 
 (s/fdef clj-path? :args (s/cat :p fs/path?) :ret boolean?)
 (defn clj-path? [path]
-  (boolean (re-find #"\.clj$" (str path))))
+  (str/ends-with? (str path) ".clj"))
 
 (defn cljc-path? [path]
-  (boolean (re-find #"\.cljc$" (str path))))
+  (str/ends-with? (str path) ".cljc"))
 
 (defn cljs-path? [path]
-  (boolean (re-find #"\.cljs$" (str path))))
+  (str/ends-with? (str path) ".cljs"))
 
 (defn clj*-path? [path]
-  (or (clj-path? path)
-      (cljc-path? path)
-      (cljs-path? path)))
+  (let [s (str path)]
+    (or (str/ends-with? s ".clj")
+        (str/ends-with? s ".cljc")
+        (str/ends-with? s ".cljs"))))
 
 (defn js-path? [path]
-  (re-find #"\.js$" (str path)))
+  (str/ends-with? (str path) ".js"))
 
 (defn test-path? [path]
-  (boolean (re-find #"_test.clj" (str path))))
+  (str/includes? (str path) "_test.clj"))
 
 (defn src-path? [path]
   (not (test-path? path)))
-
-(defn path-
-  "given the path to a .clj file, return the namespace"
-  [^Path path]
-  {:post [(symbol? %)]}
-  (-> path
-      .toFile
-      (slurp)
-      (read-string)
-      (second)))
 
 (defn requires-aot?
   [ns-decl]


### PR DESCRIPTION
- Remove `validate!` calls from `kwargs`, `emit-bazel` hot paths; weaken `:post` conditions from spec
  checks to `map?`
- Remove unused `src->label` and `path-` functions
- Replace regex path predicates with `str/ends-with?` and `str/includes?`

(written by Claude)