### PR TITLE
Watch deps.edn

### DIFF
--- a/extensions.bzl
+++ b/extensions.bzl
@@ -13,6 +13,7 @@ def _module_impl(ctx):
             root_module_name = mod.name
         for attr in mod.tags.install:
             repos.append(attr.repo_name)
+            ctx.watch(attr.deps_edn)
             clojure_tools_deps(name = attr.repo_name,
                                repo_name = attr.repo_name,
                                aliases = attr.aliases,


### PR DESCRIPTION
`ctx.watch()` the deps.edn file. Required with bazel modules, this tells bazel to invalidate and re-run the module when the deps.edn content changes. Without it, changing deps.edn won't update `@deps`, and your downstream project will have inscrutible "can't find class Foo" after adding foo to deps. 