### PR TITLE
gen_srcs: drop `data = []` / `srcs = []` noise from BUILD output

### DIFF
--- a/src/rules_clojure/gen_build.clj
+++ b/src/rules_clojure/gen_build.clj
@@ -177,11 +177,14 @@
 (defn emit-bazel-kwargs
   "Return a seq of \"k = v\" entry strings, sorted by buildifier attribute priority.
    Sortable list-typed values (per `sortable-list-attrs`) are sorted by `label-sort-key`.
-   Vector values render inline (<=1 element) or multi-line via `emit-vector`."
+   Vector values render inline (<=1 element) or multi-line via `emit-vector`.
+   Entries whose value is an empty collection are dropped — `data = []` /
+   `srcs = []` are noise, not declarations."
   [kwargs]
   {:pre [(map? kwargs)]
    :post [(sequential? %)]}
   (->> (:x kwargs)
+       (remove (fn [[_ v]] (and (coll? v) (empty? v))))
        sort-kwargs-entries
        (map (fn [[k v]]
               (let [v-str (cond

--- a/test/rules_clojure/gen_build_test.clj
+++ b/test/rules_clojure/gen_build_test.clj
@@ -214,6 +214,29 @@
                   ")")
              result)))))
 
+(deftest test-empty-collection-attrs-dropped
+  (testing "empty list/map values are omitted from the rendered call"
+    (let [result (gb/emit-bazel
+                  (list 'filegroup
+                        (gb/kwargs {:name "x"
+                                    :srcs ["a.clj"]
+                                    :data []})))]
+      (is (= "filegroup(\n    name = \"x\",\n    srcs = [\"a.clj\"],\n)"
+             result)
+          "data = [] is noise — bazel default is [] anyway — and must not render")))
+  (testing "non-empty values survive"
+    (let [result (gb/emit-bazel
+                  (list 'filegroup
+                        (gb/kwargs {:name "x"
+                                    :srcs ["a.clj"]
+                                    :data ["//b:c"]})))]
+      (is (str/includes? result "data = [\"//b:c\"]"))))
+  (testing "non-collection falsy/zero values are preserved"
+    (is (str/includes?
+         (gb/emit-bazel (list 'rule (gb/kwargs {:name "x" :testonly false})))
+         "testonly = False")
+        "False must render, not be confused with an empty collection")))
+
 (deftest test-attr-sorting
   (testing "name first, then by priority, then alphabetical"
     (let [result (gb/emit-bazel


### PR DESCRIPTION
## Problem

`gen_srcs` always emits `data = []` and `srcs = []` on `filegroup`s that have no subdir-data or no in-dir sources:

```python
filegroup(
    name = "__clj_files",
    srcs = ["foo.clj"],
    data = [],            # noise
)
```

Buildifier doesn't strip empty list attrs and humans never write them, so every generated BUILD file carries a few attributes that mean nothing.

## Solution

`emit-bazel-kwargs` now skips entries whose value is an empty collection before rendering:

```clojure
(->> (:x kwargs)
     (remove (fn [[_ v]] (and (coll? v) (empty? v))))
     sort-kwargs-entries
     ...)
```

Same machinery, two fewer lines per filegroup output.

## Verified

Regenerating a downstream consumer's BUILD files via `bazel run //:gen_srcs` wrote 996 BUILD files; the entire diff is:

```
911 -    data = [],
 85 -    srcs = [],
```

i.e. exactly the empty-attr lines, no semantic changes.

Related: #99 (independent fix surfaced by the same investigation).
