### PR TITLE
Mark deps extension as reproducible

### DIFF
--- a/extensions.bzl
+++ b/extensions.bzl
@@ -22,7 +22,8 @@ def _module_impl(ctx):
                                env = attr.env,
                                root_module_name = root_module_name or "")
     return ctx.extension_metadata(root_module_direct_deps="all",
-                                  root_module_direct_dev_deps=[])
+                                  root_module_direct_dev_deps=[],
+                                  reproducible = True)
 
 deps = module_extension(
   implementation = _module_impl,


### PR DESCRIPTION
Marks the `deps` module extension as `reproducible = True`.

Per the [Bazel docs](https://bazel.build/external/extension#specify_reproducibility_and_use_facts), an extension qualifies when it "always defines the same repositories given the same inputs … and in particular doesn't rely on any downloads that aren't guarded by a checksum". `clojure_tools_deps` produces the same outputs given the same `deps.edn` and `clj_version`:

- Clojure CLI download is SHA256-pinned via `clj_version` (see `CLJ_VERSIONS_MAC` / `CLJ_VERSIONS_LINUX` in `tools_deps.bzl`)
- `gen-build` runs with [`-Srepro`](https://clojure.org/reference/clojure_cli#opt_srepro), which omits the user-level `~/.clojure/deps.edn` so resolution doesn't depend on user config
- Maven artifacts at pinned coordinates are immutable by Maven Central policy, so the same `deps.edn` resolves to the same artifact set

The effect is that the `deps` extension no longer records `deps.edn` content hashes in `MODULE.bazel.lock`. Those entries were invalidation hints, not integrity checks — Bazel re-reads `deps.edn` on every re-evaluation regardless.