### PR TITLE
feat: emit per-test JUnit XML from the clojure_test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ clojure_test(
 
 Delegates to `java_test`, using `rules-clojure.testrunner` as the main class. `clojure_test` uses `clojure.test` to run all tests in a single namespace. Note that bazel defines a test as a script that returns exit code 0, so each `clojure_test` is a separate JVM, which makes startup time relevant.
 
+When bazel sets `XML_OUTPUT_FILE` (it does for every test action), the runner also writes a JUnit XML report there, with one `<testcase>` per `deftest` (including per-test timing) and `<failure>`/`<error>` detail. This means callers (e.g. CI) get structured, per-test results to display, rather than just relying on bazel's bare pass/fail exit code.
+
 ## tools.deps dependencies (optional)
 In your WORKSPACE:
 ```

--- a/src/rules_clojure/testrunner.clj
+++ b/src/rules_clojure/testrunner.clj
@@ -1,11 +1,70 @@
 (ns rules-clojure.testrunner
   (:require [clojure.pprint :refer [pprint]]
             [clojure.stacktrace :as stack]
+            [clojure.string :as str]
             [clojure.test :as c.test])
   (:gen-class))
 
 (defn pp-str [x]
   (with-out-str (pprint x)))
+
+;; ----------------------------------------------------------------------------
+;; Result accumulation
+;;
+;; clojure.test reports its progress through the `report` multimethod. We piggy
+;; back on the var-level lifecycle events (:begin-test-var / :end-test-var) to
+;; build one JUnit `<testcase>` per `deftest`, recording any failures/errors and
+;; per-test timing along the way. The collected data is later serialized to the
+;; file named by $XML_OUTPUT_FILE so Bazel can surface structured, per-test
+;; results.
+;; ----------------------------------------------------------------------------
+
+(def ^:dynamic *results*
+  "Atom holding {:cases [testcase ...]}. Each testcase is
+   {:name :classname :time :failures [] :errors []}. The live path also carries
+   a transient :start (nanoTime) between :begin-test-var and :end-test-var."
+  (atom {:cases []}))
+
+(defn- make-testcase
+  [name classname]
+  {:name name :classname classname
+   :time 0 :failures [] :errors []})
+
+(defn- update-current!
+  "If a report event arrives with
+   no active test var (clojure.test does not pair every event with a var — e.g.
+   a stray :error reported outside test-var), synthesize a placeholder case so
+   the event is still reported rather than lost."
+  [f]
+  (swap! *results* update :cases
+         (fn [cases]
+           (if (seq cases)
+             (conj (pop cases) (f (peek cases)))
+             [(f (make-testcase "uncaught" "unknown"))]))))
+
+(defn- contexts-str []
+  (when (seq c.test/*testing-contexts*)
+    (str (c.test/testing-contexts-str) "\n")))
+
+(defn- detail
+  [m render-actual]
+  {:message (c.test/testing-vars-str m)
+   :body (str (when-let [msg (:message m)] (str msg "\n"))
+              (contexts-str)
+              "expected: " (pp-str (:expected m)) "\n"
+              "actual: " (render-actual (:actual m)))})
+
+(defn- fail->detail [m] (detail m pp-str))
+
+(defn- error->detail [m]
+  (detail m (fn [actual]
+              (if (instance? Throwable actual)
+                (with-out-str (stack/print-cause-trace actual c.test/*stack-trace-depth*))
+                (pp-str actual)))))
+
+;; ----------------------------------------------------------------------------
+;; Pretty console reporting + result recording
+;; ----------------------------------------------------------------------------
 
 (defmulti
   ^{:doc "Prettier report printing method.
@@ -25,7 +84,8 @@
     (when (seq c.test/*testing-contexts*) (println (c.test/testing-contexts-str)))
     (when-let [message (:message m)] (println message))
     (print "expected:\n" (pp-str (:expected m)))
-    (print "actual:\n" (pp-str (:actual m)))))
+    (print "actual:\n" (pp-str (:actual m))))
+  (update-current! (fn [c] (update c :failures conj (fail->detail m)))))
 
 (defmethod pretty-report :error [m]
   (c.test/with-test-out
@@ -38,7 +98,8 @@
     (let [actual (:actual m)]
       (if (instance? Throwable actual)
         (stack/print-cause-trace actual c.test/*stack-trace-depth*)
-        (prn actual)))))
+        (prn actual))))
+  (update-current! (fn [c] (update c :errors conj (error->detail m)))))
 
 (defmethod pretty-report :summary [m]
   (c.test/with-test-out
@@ -50,23 +111,141 @@
   (c.test/with-test-out
     (println "\nTesting" (ns-name (:ns m)))))
 
-;; Ignore these message types:
+(defmethod pretty-report :begin-test-var [m]
+  (let [vm (meta (:var m))]
+    (swap! *results* update :cases conj
+           (assoc (make-testcase (str (:name vm)) (str (ns-name (:ns vm))))
+                  :start (System/nanoTime)))))
+
+(defmethod pretty-report :end-test-var [_]
+  (update-current!
+   (fn [c]
+     (-> (if-let [start (:start c)]
+           (assoc c :time (/ (double (- (System/nanoTime) start)) 1e9))
+           c)
+         (dissoc :start)))))
+
+;; Ignore this message type:
 (defmethod pretty-report :end-test-ns [_])
-(defmethod pretty-report :begin-test-var [_])
-(defmethod pretty-report :end-test-var [_])
+
+;; ----------------------------------------------------------------------------
+;; JUnit XML serialization
+;; ----------------------------------------------------------------------------
+
+(defn- xml-escape
+  "Escape markup characters for use in element text content, and strip
+   characters that are illegal in XML 1.0."
+  [s]
+  (-> (str/escape (str s) {\& "&amp;" \< "&lt;" \> "&gt;" \" "&quot;" \' "&apos;"})
+      (str/replace #"[\x00-\x08\x0B\x0C\x0E-\x1F]" "")))
+
+(defn- xml-escape-attr
+  "Like xml-escape, but also encodes the whitespace characters that an XML
+   parser would otherwise normalize away inside an attribute value (tab,
+   newline, carriage return) as numeric character references."
+  [s]
+  (str/escape (xml-escape s) {\tab "&#9;" \newline "&#10;" \return "&#13;"}))
+
+(defn- fmt-time
+  "Format seconds with a fixed locale so the decimal separator is always '.'."
+  [t]
+  (String/format java.util.Locale/US "%.3f" (object-array [(double (or t 0))])))
+
+(defn- detail->xml [tag {:keys [message body]}]
+  (str "    <" tag " message=\"" (xml-escape-attr message) "\">"
+       (xml-escape body)
+       "</" tag ">"))
+
+(defn- testcase->xml [{:keys [name classname time failures errors]}]
+  (let [children (concat (map #(detail->xml "failure" %) failures)
+                         (map #(detail->xml "error" %) errors))
+        open (str "    <testcase name=\"" (xml-escape-attr name)
+                  "\" classname=\"" (xml-escape-attr classname)
+                  "\" time=\"" (fmt-time time) "\"")]
+    (if (seq children)
+      (str open ">\n" (str/join "\n" children) "\n    </testcase>")
+      (str open "/>"))))
+
+(defn- testsuite->xml [suite-name cases]
+  (let [tests (count cases)
+        failures (transduce (map (comp count :failures)) + cases)
+        errors (transduce (map (comp count :errors)) + cases)
+        time (transduce (map (comp double #(or % 0) :time)) + cases)]
+    (str "  <testsuite name=\"" (xml-escape-attr suite-name)
+         "\" tests=\"" tests
+         "\" failures=\"" failures
+         "\" errors=\"" errors
+         "\" time=\"" (fmt-time time) "\">\n"
+         (str/join "\n" (map testcase->xml cases))
+         "\n  </testsuite>")))
+
+(defn results->junit-xml
+  "Serialize accumulated results to a JUnit XML string. Testcases are grouped
+   into one `<testsuite>` per namespace, in first-seen order."
+  [{:keys [cases]}]
+  (let [grouped (group-by :classname cases)
+        classnames (into [] (comp (map :classname) (distinct)) cases)]
+    (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+         "<testsuites>\n"
+         (str/join "\n" (map #(testsuite->xml % (grouped %)) classnames))
+         (when (seq classnames) "\n")
+         "</testsuites>\n")))
+
+(defn- write-xml!
+  "Serialize results to `out` (a file path) when it is non-nil. Best-effort: a
+   write failure must never mask the test outcome or a load error, so it is
+   logged rather than thrown."
+  [out results]
+  (when out
+    (try
+      (spit out (results->junit-xml results))
+      (catch Throwable t
+        (println "Failed to write" out ":" t)))))
+
+(defn- record-error!
+  "Append a synthetic errored testcase to *results* describing a Throwable that
+   escaped the normal per-test reporting (a load failure or a fixture throw).
+   Any cases recorded before the throw are preserved."
+  [name classname message t]
+  (swap! *results* update :cases conj
+         (-> (make-testcase name classname)
+             (update :errors conj
+                     {:message message
+                      :body (with-out-str (stack/print-cause-trace t))}))))
+
+(defn run-ns
+  "Run all tests in the-ns, write a JUnit XML report to `out-path` when it is
+   non-nil, and return the clojure.test summary. Performs no System/exit and
+   reads no environment, so it can be driven directly from tests."
+  [the-ns out-path]
+  (binding [*results* (atom {:cases []})]
+    (let [summary
+          (try
+            (require the-ns)
+            (try
+              ;; run-tests reports per-test results into
+              ;; *results* as it goes. clojure.test lets fixture exceptions
+              ;; (:once / :each) propagate out of run-tests rather than
+              ;; catching them, so a throw here is a fixture/runtime error
+              ;; that may follow already-recorded results — attribute it as a
+              ;; distinct errored case rather than a "load" failure.
+              (binding [c.test/report pretty-report]
+                (c.test/run-tests the-ns))
+              (catch Throwable t
+                (record-error! "fixture-error" (str the-ns)
+                               (str "Error running tests in " the-ns) t)
+                (println t)
+                {:fail 0 :error 1}))
+            (catch Throwable t
+              (record-error! "load" (str the-ns)
+                             (str "Failed to load " the-ns) t)
+              (println t)
+              {:fail 0 :error 1}))]
+      (write-xml! out-path @*results*)
+      summary)))
 
 (defn -main [& args]
   (assert (string? (first args)) (print-str "first argument must be a string, got" args))
-  (let [the-ns (-> args first symbol)]
-    (try
-      (require the-ns)
-      (binding [c.test/report pretty-report]
-        (let [test-report (clojure.test/run-tests the-ns)]
-          (println test-report)
-          (if (and (zero? (:fail test-report))
-                   (zero? (:error test-report)))
-            (System/exit 0)
-            (System/exit 1))))
-      (catch Throwable t
-        (println t)
-        (System/exit 1)))))
+  (let [summary (run-ns (symbol (first args)) (System/getenv "XML_OUTPUT_FILE"))]
+    (println summary)
+    (System/exit (if (and (zero? (:fail summary)) (zero? (:error summary))) 0 1))))

--- a/test/rules_clojure/BUILD
+++ b/test/rules_clojure/BUILD
@@ -27,7 +27,7 @@ clojure_library(name="aot-only-fixture",
                 deps=ClojureJars)
 
 clojure_library(name="test-deps",
-                resources=glob(["*.clj"], exclude=["aot_only_fixture.clj"]),
+                resources=glob(["*.clj", "testrunner_fixtures/*.clj"], exclude=["aot_only_fixture.clj"]),
                 resource_strip_prefix="test/",
                 deps=["//src/rules_clojure:libworker",
                       "//src/rules_clojure:libcompile",
@@ -78,3 +78,7 @@ clojure_test(name="compile-test",
              test_ns = "rules-clojure.compile-test",
              data=["//src/rules_clojure:bootstrap"],
              env={"TEST_JARS": "$(rlocationpaths //src/rules_clojure:bootstrap)"})
+
+clojure_test(name="testrunner-test",
+             deps=[":test-deps"],
+             test_ns = "rules-clojure.testrunner-test")

--- a/test/rules_clojure/testrunner_fixtures/bad_fixture.clj
+++ b/test/rules_clojure/testrunner_fixtures/bad_fixture.clj
@@ -1,0 +1,9 @@
+(ns rules-clojure.testrunner-fixtures.bad-fixture
+  "Fixture namespace driven by testrunner-test: a :once fixture that throws
+   before any test runs, exercising the fixture-error path. Not run as a target
+   of its own."
+  (:require [clojure.test :refer [deftest is use-fixtures]]))
+
+(use-fixtures :once (fn [_] (throw (ex-info "fixture boom" {}))))
+
+(deftest never-runs (is true))

--- a/test/rules_clojure/testrunner_fixtures/mixed.clj
+++ b/test/rules_clojure/testrunner_fixtures/mixed.clj
@@ -1,0 +1,10 @@
+(ns rules-clojure.testrunner-fixtures.mixed
+  "Fixture namespace driven by testrunner-test: one passing test, one assertion
+   failure, and one test that throws. Not run as a target of its own."
+  (:require [clojure.test :refer [deftest is]]))
+
+(deftest a-pass (is true))
+
+(deftest a-fail (is (= 1 2)))
+
+(deftest an-error (throw (ex-info "boom <&>" {})))

--- a/test/rules_clojure/testrunner_fixtures/passing.clj
+++ b/test/rules_clojure/testrunner_fixtures/passing.clj
@@ -1,0 +1,8 @@
+(ns rules-clojure.testrunner-fixtures.passing
+  "Fixture namespace driven by testrunner-test: two passing tests, no failures
+   or errors. Not run as a target of its own."
+  (:require [clojure.test :refer [deftest is]]))
+
+(deftest a-pass (is true))
+
+(deftest another-pass (is (= 1 1)))

--- a/test/rules_clojure/testrunner_test.clj
+++ b/test/rules_clojure/testrunner_test.clj
@@ -1,0 +1,151 @@
+(ns rules-clojure.testrunner-test
+  (:require [clojure.test :as t :refer [deftest is]]
+            [clojure.xml :as xml]
+            [rules-clojure.testrunner :as tr])
+  (:import [java.io ByteArrayInputStream Closeable File PrintWriter StringWriter]))
+
+(defn parse
+  "Parse an XML string into clojure.xml's element tree. Doubles as a
+   well-formedness check — malformed XML throws."
+  [^String s]
+  (xml/parse (ByteArrayInputStream. (.getBytes s "UTF-8"))))
+
+(defn elements
+  "Child element nodes of `node`, skipping the whitespace text nodes that the
+   SAX parser emits between our pretty-printed elements."
+  [node]
+  (filter map? (:content node)))
+
+(defn by-name
+  "Index testcase element nodes by their name attribute. Test execution order
+   isn't guaranteed, so we look cases up by name rather than position."
+  [cases]
+  (into {} (map (juxt #(get-in % [:attrs :name]) identity)) cases))
+
+;; Serializer golden tests: hand-built inputs cover shaping a single-namespace
+;; live run can't reach (multiple suites, escaping). The expected XML is embedded
+;; adjacent to each test so a format change surfaces as a readable diff here.
+
+(def sample
+  {:cases [{:name "passing-test" :classname "my.ns" :time 0.01
+            :failures [] :errors []}
+           {:name "failing-test" :classname "my.ns" :time 0.02
+            :failures [{:message "my.ns/failing-test (core.clj:5)"
+                        :body "expected: 1  actual: 2"}]
+            :errors []}
+           {:name "erroring-test" :classname "other.ns" :time 0.0
+            :failures []
+            :errors [{:message "other.ns/erroring-test (core.clj:9)"
+                      :body "boom <&> \"quote\""}]}]})
+
+(def sample-xml
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites>
+  <testsuite name=\"my.ns\" tests=\"2\" failures=\"1\" errors=\"0\" time=\"0.030\">
+    <testcase name=\"passing-test\" classname=\"my.ns\" time=\"0.010\"/>
+    <testcase name=\"failing-test\" classname=\"my.ns\" time=\"0.020\">
+    <failure message=\"my.ns/failing-test (core.clj:5)\">expected: 1  actual: 2</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name=\"other.ns\" tests=\"1\" failures=\"0\" errors=\"1\" time=\"0.000\">
+    <testcase name=\"erroring-test\" classname=\"other.ns\" time=\"0.000\">
+    <error message=\"other.ns/erroring-test (core.clj:9)\">boom &lt;&amp;&gt; &quot;quote&quot;</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+")
+
+(deftest sample-serializes-to-golden
+  (is (= sample-xml (tr/results->junit-xml sample))))
+
+(def empty-xml
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites>
+</testsuites>
+")
+
+(deftest empty-results-serialize-to-golden
+  (is (= empty-xml (tr/results->junit-xml {:cases []}))))
+
+(def multiline-results
+  {:cases [{:name "t" :classname "my.ns" :time 0.0
+            :failures [{:message "line1\nline2" :body "b"}]
+            :errors []}]})
+
+(def multiline-xml
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites>
+  <testsuite name=\"my.ns\" tests=\"1\" failures=\"1\" errors=\"0\" time=\"0.000\">
+    <testcase name=\"t\" classname=\"my.ns\" time=\"0.000\">
+    <failure message=\"line1&#10;line2\">b</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+")
+
+(deftest multiline-message-serializes-to-golden
+  ;; A newline in a failure message must be encoded as a numeric reference so it
+  ;; survives as an attribute value rather than being normalized to a space.
+  (is (= multiline-xml (tr/results->junit-xml multiline-results))))
+
+(deftest end-var-without-begin-leaves-zero-time
+  (binding [tr/*results* (atom {:cases []})]
+    (tr/pretty-report {:type :end-test-var})
+    (let [c (first (:cases @tr/*results*))]
+      (is (= 0 (:time c)) "no start recorded -> time stays at its 0 default")
+      (is (not (contains? c :start)) ":start must not leak into the recorded case"))))
+
+(defn run-fixture
+  "Run the-ns through the real runner, writing XML to a temp file, and return
+   {:summary <clojure.test summary> :doc <parsed XML root>}. Silences the
+   runner's console + test output."
+  [the-ns]
+  (let [out (File/createTempFile "junit" ".xml")]
+    ;; The JDK ships no Closeable that deletes a file, so reify one and let
+    ;; with-open delete the temp file on scope exit.
+    (with-open [_ (reify Closeable (close [_] (.delete out)))]
+      (let [sink (PrintWriter. (StringWriter.))
+            summary (binding [*out* sink, t/*test-out* sink]
+                      (tr/run-ns the-ns (.getAbsolutePath out)))]
+        {:summary summary :doc (parse (slurp out))}))))
+
+(deftest passing-namespace-runs-clean
+  (let [{:keys [summary doc]} (run-fixture 'rules-clojure.testrunner-fixtures.passing)
+        suites (elements doc)
+        cases (elements (first suites))]
+    (is (zero? (:fail summary)))
+    (is (zero? (:error summary)))
+    (is (= 1 (count suites)) "one suite for the one namespace run")
+    (is (= "rules-clojure.testrunner-fixtures.passing"
+           (get-in (first suites) [:attrs :name])))
+    (is (= 2 (count cases)))
+    (is (every? #(empty? (elements %)) cases) "passing tests have no children")
+    (is (every? #(<= 0 (Double/parseDouble (get-in % [:attrs :time]))) cases)
+        "each testcase carries a non-negative time")))
+
+(deftest mixed-namespace-classifies-and-counts
+  (let [{:keys [summary doc]} (run-fixture 'rules-clojure.testrunner-fixtures.mixed)
+        suite (first (elements doc))
+        cases (by-name (elements suite))]
+    (is (= 1 (:fail summary)))
+    (is (= 1 (:error summary)))
+    (is (= "3" (get-in suite [:attrs :tests])))
+    (is (= "1" (get-in suite [:attrs :failures])))
+    (is (= "1" (get-in suite [:attrs :errors])))
+    (is (empty? (elements (cases "a-pass"))) "passing test is self-closing")
+    (is (= [:failure] (map :tag (elements (cases "a-fail")))) "assertion failure -> <failure>")
+    (is (= [:error] (map :tag (elements (cases "an-error")))) "thrown exception -> <error>")))
+
+(deftest fixture-throw-becomes-errored-case
+  (let [{:keys [summary doc]} (run-fixture 'rules-clojure.testrunner-fixtures.bad-fixture)
+        cases (by-name (mapcat elements (elements doc)))]
+    (is (= 1 (:error summary)) "a throwing :once fixture is one error")
+    (is (contains? cases "fixture-error"))
+    (is (= [:error] (map :tag (elements (cases "fixture-error")))))))
+
+(deftest missing-namespace-becomes-load-error
+  (let [{:keys [summary doc]} (run-fixture 'rules-clojure.testrunner-fixtures.does-not-exist)
+        cases (by-name (mapcat elements (elements doc)))]
+    (is (= 1 (:error summary)) "a namespace that won't load is one error")
+    (is (contains? cases "load"))
+    (is (= [:error] (map :tag (elements (cases "load")))))))


### PR DESCRIPTION
## Summary

The `clojure_test` runner only reported a pass/fail exit code, so Bazel
generated a single stub JUnit result per target. The runner now emits structured
JUnit XML [to `$XML_OUTPUT_FILE`](https://bazel.build/reference/test-encyclopedia), so Bazel surfaces **one result per `deftest`**
with timing and failure/error detail instead of a synthesised stub.

## What changed

- `testrunner.clj` hooks `clojure.test`'s `:begin-test-var` / `:end-test-var`
  events to build one `<testcase>` per `deftest` (grouped into one
  `<testsuite>` per namespace), then serialises to `$XML_OUTPUT_FILE`.
- Assertion failures → `<failure>`, uncaught exceptions → `<error>`, each with
  message + expected/actual or stacktrace.
- Namespace-load failures and fixture exceptions surface as errored testcases
  rather than disappearing into the exit code.
- XML is hand-rolled (no new deps) so the isolated AOT bootstrap keeps working;
  console output is unchanged.

In addition to producing the JUnit report, running `bazel test` with the `--test_summary=detailed` flag will have bazel output per-deftest results, including timing, like:

```
//test:ci_failure_demo_test.test                                         FAILED in 6.5s
    PASSED  ci-failure-demo-test.slow-demo (5.0s)
    PASSED  ci-failure-demo-test.passing-demo (0.0s)
    FAILED  ci-failure-demo-test.assertion-failure-demo (0.0s)
    ERROR   ci-failure-demo-test.uncaught-error-demo (0.0s)
    FAILED  ci-failure-demo-test.multiple-failures-demo (0.0s)
    FAILED  ci-failure-demo-test.property-failure-demo (0.0s)
```

## Notes

- `<system-out>` is deliberately omitted. The old path wrote no
  `$XML_OUTPUT_FILE`, so Bazel's stub generator
  ([`generate-xml.sh`](https://github.com/bazelbuild/bazel/blob/8.6.0/tools/test/generate-xml.sh))
  embedded the full `test.log` in `<system-out>`; emitting our own XML drops
  that auto-embedded log. This matches Bazel's own
  [`AntXmlResultWriter`](https://github.com/bazelbuild/bazel/blob/8.6.0/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/AntXmlResultWriter.java)
  (which leaves `<system-out>` empty), and the console log is still captured in
  `test.log`.
