### PR TITLE
Add support for overriding test main_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Delegates to `java_test`, using `rules-clojure.testrunner` as the main class. `c
 
 When bazel sets `XML_OUTPUT_FILE` (it does for every test action), the runner also writes a JUnit XML report there, with one `<testcase>` per `deftest` (including per-test timing) and `<failure>`/`<error>` detail. This means callers (e.g. CI) get structured, per-test results to display, rather than just relying on bazel's bare pass/fail exit code.
 
+A `main_class` can be supplied, which must refer to a _class_ (see [`gen-class`](https://clojuredocs.org/clojure.core/gen-class)).
+The main entrypoint will be called with one argument: The Clojure namespace to test.
+It should write a JUnit XML report to `$XML_OUTPUT_FILE` and exit with 0 for a pass and non-zero for failure.
+See the [default runner](https://github.com/griffinbank/rules_clojure/blob/e3eabc6621ebc3280410da2a20b56929d63e76ae/src/rules_clojure/testrunner.clj) for inspiration.
+
 ## tools.deps dependencies (optional)
 In your WORKSPACE:
 ```

--- a/rules.bzl
+++ b/rules.bzl
@@ -45,14 +45,14 @@ clojure_repl = rule(
     toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
     implementation = _clojure_repl_impl)
 
-def clojure_test(name, *, test_ns, deps=[], runtime_deps=[], **kwargs):
+def clojure_test(name, *, test_ns, deps=[], runtime_deps=[], main_class="rules_clojure.testrunner", **kwargs):
     # ideally the library name and the bin name would be the same. They can't be.
     # clojure src files would like to depend on `foo_test`, so mangle the test binary, not the src jar name
 
     native.java_test(name=name,
                      runtime_deps = deps + runtime_deps + ["@rules_clojure//src/rules_clojure:testrunner"],
                      use_testrunner = False,
-                     main_class="rules_clojure.testrunner",
+                     main_class=main_class,
                      args = [test_ns],
                      **kwargs)
 


### PR DESCRIPTION
This allows doing this:

```clojure
(ns griffin.test.runner
  {:bazel/clojure_library {:deps ["@rules_clojure//src/rules_clojure:testrunner"]}}
  (:require [rules-clojure.testrunner :as testrunner])
  (:gen-class))

(defn -main
  [& args]
  (binding [*print-length* 1]
    (apply testrunner/-main args)))
```

by setting this in your clojure_test deps.edn alias:

```clojure
:clojure_test {:main_class "griffin.test.runner"
               :deps ["//src/griffin/test:runner"]}
```
