### PR TITLE
feat: Fix `deps.edn` update re-resolution

### DIFF
--- a/rules/tools_deps.bzl
+++ b/rules/tools_deps.bzl
@@ -118,6 +118,9 @@ def _run_gen_build(ctx):
         fail("gen build failed:", ret.return_code, ret.stdout, ret.stderr)
 
 def _tools_deps_impl(repository_ctx):
+    # Refetch whenever deps.edn's contents change, but still support
+    # reproducibility because outputs are dependent on inputs.
+    repository_ctx.watch(repository_ctx.path(repository_ctx.attr.deps_edn))
     _install_tools_deps(repository_ctx)
     _symlink_repository(repository_ctx)
     _run_gen_build(repository_ctx)


### PR DESCRIPTION
Because we weren't watching `deps.edn` as part of the repository rule, a change to the deps could leave folks with a stale bazel repo that didn't contain the new libs. This should fix that, while still allowing the rule to be deterministic so we don't need a hash of the file or similar in our `MODULE.bazel.lock` for banksy that keeps changing awkwardly.

Prior to this change:
```
12:20:39 ➜ grep -c software_amazon_awssdk "$(bazel info output_base)/external/rules_clojure++deps+deps/BUILD.bazel"
INFO: Invocation ID: 1be20517-a1a5-4077-a861-12560e69acae
330

12:20:43 ➜ git show 78401450fb^:deps.edn > deps.edn

12:20:47 ➜ with_creds.sh bazel fetch --repo @deps
INFO: Invocation ID: 3fc037ff-8edd-47ac-a9f9-948f49cfb448
INFO: All requested repos fetched successfully.

12:20:59 ➜ grep -c software_amazon_awssdk "$(bazel info output_base)/external/rules_clojure++deps+deps/BUILD.bazel"
INFO: Invocation ID: 290d6183-2a1d-499c-8489-4402d8462d29
330
```

With this change:
```
12:22:32 ➜ grep -c software_amazon_awssdk "$(bazel info output_base)/external/rules_clojure++deps+deps/BUILD.bazel"
INFO: Invocation ID: 05157a0d-ca77-4e21-ab1d-af3c7823c647
330

12:22:48 ➜ git show 78401450fb^:deps.edn > deps.edn

12:22:51 ➜ with_creds.sh bazel fetch --repo @deps
INFO: Invocation ID: 26c4fd9e-83fb-4ff4-a181-d001df25797f
mkdir: /private/var/tmp/_bazel_meyersd/b58577c99ee3225a2235742e020e991e/external/rules_clojure++deps+deps/tools.deps: File exists
cp: /private/var/tmp/_bazel_meyersd/b58577c99ee3225a2235742e020e991e/external/rules_clojure++deps+deps/tools.deps/deps.edn and deps.edn are identical (not copied).
cp: /private/var/tmp/_bazel_meyersd/b58577c99ee3225a2235742e020e991e/external/rules_clojure++deps+deps/tools.deps/example-deps.edn and example-deps.edn are identical (not copied).
cp: /private/var/tmp/_bazel_meyersd/b58577c99ee3225a2235742e020e991e/external/rules_clojure++deps+deps/tools.deps/tools.edn and tools.edn are identical (not copied).
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
INFO: All requested repos fetched successfully.

12:23:07 ➜ grep -c software_amazon_awssdk "$(bazel info output_base)/external/rules_clojure++deps+deps/BUILD.bazel"
INFO: Invocation ID: eeb04bad-6e97-4a86-9c6e-977c7ffce9aa
0
```