### PR TITLE
Allow custom deps repo name for gen_srcs

### DIFF
--- a/rules/tools_deps.bzl
+++ b/rules/tools_deps.bzl
@@ -139,9 +139,9 @@ clojure_tools_deps = repository_rule(
              "_rules_clj_deps": attr.label(default="@rules_clojure//:deps.edn"),
              "_rules_clj_src": attr.label(default="@rules_clojure//:src")})
 
-def clojure_gen_srcs(name):
-    native.alias(name=name,
-                 actual= "@deps//scripts:gen_srcs")
+def clojure_gen_srcs(name, deps_repo_name = "deps"):
+    native.alias(name = name,
+                 actual = "@" + deps_repo_name + "//scripts:gen_srcs")
 
 def clojure_gen_namespace_loader(name, output_filename, output_ns_name, output_fn_name, in_dirs, exclude_nses, platform, deps_edn):
     native.java_binary(name=name,


### PR DESCRIPTION
Root bazel modules that use rules_clojure may want to use the deps repo name @deps. If those root bazel modules also want to depend on modules that use rules_clojure, we need a way to allow for deps repo names to be named something else so they don't clash. Those modules that also use rules_clojure may also want to use gen_srcs, and this change allows for that.